### PR TITLE
Change title Rouen event

### DIFF
--- a/src/app/events/[slug]/page.tsx
+++ b/src/app/events/[slug]/page.tsx
@@ -27,7 +27,7 @@ export async function generateMetadata({
   const event = await collections.event.getBySlug(params.slug);
 
   return {
-    title: event.name,
+    title: event.title,
     description: event.excerpt,
     alternates: {
       canonical: `/events/${event.metadata.slug}`,

--- a/src/content/collections.ts
+++ b/src/content/collections.ts
@@ -51,6 +51,7 @@ const collections = {
   event: defineCollection({
     folder: "event",
     schema: z.object({
+      title: z.string(),
       name: z.string(),
       date: z.date().optional(),
       location: z

--- a/src/content/event/2024-06-07-rouen.mdx
+++ b/src/content/event/2024-06-07-rouen.mdx
@@ -1,4 +1,5 @@
 ---
+title: Fork it! Rouen 2024
 name: Rouen, France
 date: 2024-06-07
 location:


### PR DESCRIPTION
## Description : 
I added a props to manage the title of event pages because the `name` is used somwhere else in the page. I also change the title from "Rouen, France" to "Fork it! Rouen 2024"