### PR TITLE
Add a page for each talk with the title, the speaker and the details

### DIFF
--- a/src/app/events/[slug]/header.tsx
+++ b/src/app/events/[slug]/header.tsx
@@ -101,7 +101,7 @@ export function Header(props: Readonly<{ event: Event }>) {
             {navigation.map((item) => (
               <a
                 key={item.name}
-                href={item.href}
+                href={`/events/${props.event.metadata.slug}${item.href}`}
                 className="text-sm font-semibold leading-6 text-white"
               >
                 {item.name}

--- a/src/app/events/[slug]/talks.tsx
+++ b/src/app/events/[slug]/talks.tsx
@@ -1,8 +1,9 @@
 import collections, { Event } from "@/content/collections";
 import Image from "next/image";
 import DefaultImg from "@/../public/speakers/speaker-default.jpg";
+import Link from "next/link";
 
-async function Talk(props: Readonly<{ talk: { slug: string } }>) {
+async function Talk(props: Readonly<{ talk: { slug: string }; event: Event }>) {
   const talk = await collections.talk.getBySlug(props.talk.slug);
   const speakers = [];
   for (let i = 0; i < talk.speakers.length; i++) {
@@ -11,7 +12,9 @@ async function Talk(props: Readonly<{ talk: { slug: string } }>) {
   const content = (
     <div className="mx-auto flex w-full max-w-[60ch] gap-4">
       <div className="flex flex-1 flex-col gap-1 text-balance">
-        <h3 className="text-xl font-semibold">{talk.title}</h3>
+        <Link href={`${props.event.metadata.slug}/talks/${talk.metadata.slug}`}>
+          <h3 className="text-xl font-semibold">{talk.title}</h3>
+        </Link>
         <div className="flex flex-row gap-2">
           <div className="flex gap-2">
             {speakers.map((speaker) => (
@@ -56,6 +59,7 @@ export function Talks(props: Readonly<{ event: Event }>) {
               talk={{
                 slug: talk,
               }}
+              event={props.event}
               key={talk}
             />
           ))}

--- a/src/app/events/[slug]/talks.tsx
+++ b/src/app/events/[slug]/talks.tsx
@@ -11,9 +11,12 @@ async function Talk(props: Readonly<{ talk: { slug: string }; event: Event }>) {
   }
   const content = (
     <div className="mx-auto flex w-full max-w-[60ch] gap-4">
-      <div className="flex flex-1 flex-col gap-1 text-balance">
-        <Link href={`${props.event.metadata.slug}/talks/${talk.metadata.slug}`}>
-          <h3 className="text-xl font-semibold">{talk.title}</h3>
+      <div className="flex flex-1 flex-col gap-1">
+        <Link
+          className="text-lg hover:underline"
+          href={`${props.event.metadata.slug}/talks/${talk.metadata.slug}`}
+        >
+          <h3 className="font-semibold">{talk.title}</h3>
         </Link>
         <div className="flex flex-row gap-2">
           <div className="flex gap-2">
@@ -53,7 +56,7 @@ export function Talks(props: Readonly<{ event: Event }>) {
             or in 🇫🇷 French (with English subtitles)
           </p>
         </div>
-        <div className="mx-auto mt-12 flex flex-col gap-10 lg:grid lg:grid-cols-2">
+        <div className="mx-auto mt-12 flex flex-col gap-10 lg:grid lg:grid-cols-2 xl:grid-cols-3">
           {props.event.talks?.map((talk) => (
             <Talk
               talk={{

--- a/src/app/events/[slug]/talks/[talk]/page.tsx
+++ b/src/app/events/[slug]/talks/[talk]/page.tsx
@@ -1,0 +1,38 @@
+import collections from "@/content/collections";
+import { Metadata } from "next";
+
+type TalkPageProps = Readonly<{
+  params: { talk: string };
+}>;
+
+export async function generateStaticParams() {
+  const talks = await collections.talk.getAll();
+
+  return talks.map((talk) => ({
+    talk: talk.metadata.slug,
+  }));
+}
+
+export async function generateMetadata({
+  params,
+}: TalkPageProps): Promise<Metadata> {
+  const talk = await collections.talk.getBySlug(params.talk);
+
+  return {
+    title: talk.title,
+    openGraph: {
+      url: `https://www.forkit.community/events/${event.metadata.slug}`,
+    },
+    alternates: {
+      canonical: `/events/${event.metadata.slug}`,
+    },
+  };
+}
+
+export default function TalkPage() {
+  return (
+    <div>
+      <h1>Hello world</h1>
+    </div>
+  );
+}

--- a/src/app/events/[slug]/talks/[talk]/page.tsx
+++ b/src/app/events/[slug]/talks/[talk]/page.tsx
@@ -1,5 +1,6 @@
 import collections from "@/content/collections";
-import { Metadata } from "next";
+import Image from "next/image";
+import DefaultImg from "@/../public/speakers/speaker-default.jpg";
 
 type TalkPageProps = Readonly<{
   params: { talk: string };
@@ -13,26 +14,39 @@ export async function generateStaticParams() {
   }));
 }
 
-export async function generateMetadata({
-  params,
-}: TalkPageProps): Promise<Metadata> {
+export default async function TalkPage({ params }: TalkPageProps) {
   const talk = await collections.talk.getBySlug(params.talk);
+  const Content = (await import(`@/content/${talk.metadata.filePath}`)).default;
 
-  return {
-    title: talk.title,
-    openGraph: {
-      url: `https://www.forkit.community/events/${event.metadata.slug}`,
-    },
-    alternates: {
-      canonical: `/events/${event.metadata.slug}`,
-    },
-  };
-}
-
-export default function TalkPage() {
+  const speakers = [];
+  for (let i = 0; i < talk.speakers.length; i++) {
+    speakers[i] = await collections.speaker.getBySlug(talk.speakers[i]);
+  }
   return (
-    <div>
-      <h1>Hello world</h1>
+    <div className="prose prose-sm prose-invert mx-auto max-w-5xl p-6 prose-h2:m-0">
+      <h1>{talk.title}</h1>
+      <Content />
+      <div className="flex flex-col gap-2">
+        <div className="flex gap-4">
+          {speakers.map((speaker) => (
+            <Image
+              key={speaker.name}
+              className="mb-0 aspect-square h-28 w-28 rounded-lg"
+              src={speaker.imageUrl ?? DefaultImg}
+              alt={speaker.name}
+              width={600}
+              height={600}
+              sizes="600px"
+            />
+          ))}
+        </div>
+        <h2>
+          Presented by{" "}
+          <span className="text-primary">
+            {speakers.map((speaker) => speaker.name).join(", ")}
+          </span>
+        </h2>
+      </div>
     </div>
   );
 }

--- a/src/app/events/[slug]/talks/[talk]/page.tsx
+++ b/src/app/events/[slug]/talks/[talk]/page.tsx
@@ -1,9 +1,11 @@
 import collections from "@/content/collections";
 import Image from "next/image";
 import DefaultImg from "@/../public/speakers/speaker-default.jpg";
+import { formatDateTime } from "@/lib/utils";
+import { ICONS } from "@/components/icons";
 
 type TalkPageProps = Readonly<{
-  params: { talk: string };
+  params: { talk: string; slug: string };
 }>;
 
 export async function generateStaticParams() {
@@ -15,37 +17,71 @@ export async function generateStaticParams() {
 }
 
 export default async function TalkPage({ params }: TalkPageProps) {
+  const event = await collections.event.getBySlug(params.slug);
   const talk = await collections.talk.getBySlug(params.talk);
   const Content = (await import(`@/content/${talk.metadata.filePath}`)).default;
 
-  const speakers = [];
-  for (let i = 0; i < talk.speakers.length; i++) {
-    speakers[i] = await collections.speaker.getBySlug(talk.speakers[i]);
-  }
+  const speakers = await Promise.all(
+    talk.speakers.map(
+      async (speaker) => await collections.speaker.getBySlug(speaker),
+    ),
+  );
+
   return (
-    <div className="prose prose-sm prose-invert mx-auto max-w-5xl p-6 prose-h2:m-0">
-      <h1>{talk.title}</h1>
-      <Content />
-      <div className="flex flex-col gap-2">
-        <div className="flex gap-4">
+    <div className="flex flex-col gap-6">
+      <h1 className="m-4 my-8 text-center font-heading text-3xl font-bold tracking-tight text-white sm:text-3xl">
+        {event.date && (
+          <span className="text-primary">{formatDateTime(event.date)}</span>
+        )}{" "}
+        {event.name}
+      </h1>
+
+      <div className="mx-auto flex max-w-5xl flex-col gap-8 p-4">
+        <div className="prose prose-sm prose-invert">
+          <h2>{talk.title}</h2>
+          <Content />
+        </div>
+        <div className="flex flex-col gap-4  pb-8">
           {speakers.map((speaker) => (
-            <Image
-              key={speaker.name}
-              className="mb-0 aspect-square h-28 w-28 rounded-lg"
-              src={speaker.imageUrl ?? DefaultImg}
-              alt={speaker.name}
-              width={600}
-              height={600}
-              sizes="600px"
-            />
+            <div className="flex flex-row gap-4" key={speaker.metadata.slug}>
+              <Image
+                className="aspect-square h-28 w-28 rounded-lg"
+                src={speaker.imageUrl ?? DefaultImg}
+                alt={speaker.name}
+                width={200}
+                height={200}
+                sizes="200px"
+              />
+              <div className="flex flex-col">
+                <p className="font-heading text-lg font-semibold leading-6 text-primary">
+                  {speaker.name}
+                </p>
+                {speaker.job && (
+                  <p className="text-sm text-gray-300">{speaker.job}</p>
+                )}
+                {speaker.company && (
+                  <p className="mt-1 font-medium">{speaker.company.title}</p>
+                )}
+                {speaker.socials && (
+                  <ul className="mt-2 flex gap-x-2">
+                    {speaker.socials.map((social) => (
+                      <li key={social.type}>
+                        <a
+                          href={social.href}
+                          className=" text-gray-400 transition hover:text-primary"
+                          target="_blank"
+                        >
+                          <span className="sr-only">{social.type}</span>
+                          {ICONS[social.type]}
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            </div>
           ))}
         </div>
-        <h2>
-          Presented by{" "}
-          <span className="text-primary">
-            {speakers.map((speaker) => speaker.name).join(", ")}
-          </span>
-        </h2>
       </div>
     </div>
   );

--- a/src/content/talk/une-ode-a-la-programmation-tacite.mdx
+++ b/src/content/talk/une-ode-a-la-programmation-tacite.mdx
@@ -5,4 +5,28 @@ speakers:
   - xavier-van-de-woestyne
 ---
 
-La programmation fonctionnelle est souvent résumée à la manipulation de fonctions, que l'on peut passer en argument ou renvoyer. En somme, programmer avec des lambdas. Cette flexibilité de la manipulation de fonctions permet d'utiliser des opérateurs pour les composer, donnant lieu à un style de programmation que l'on appelle la "_programmation tacite_", ou "_point-free_", relativement populaire dans le monde Haskell, qui permet, malheureusement, très souvent, d'écrire des abominations, rendant le code illisible et **incroyablement complexe à raisonner** ! C'est pour cela que l'on lit très souvent qu'il n'y a pas de mérite à écrire des programmes dans ce style (et pour cause, une machine peut transformer du code _normal_ en _point-free_ et vice-versa). Pourtant, il arrive parfois que les outils que l'on veuille manipuler soient "_des genres de fonctions_, et que la grammaire du langage ne permette pas de les manipuler trivialement. L'utilisation d'un encodage similaire à la programmation tacite est l'utilisation de la méthode `.then`, en JavaScript, avant l'intégration des marqueurs `async/await`, dont le rôle était de palier l'expressivité du langage avec une approche abstraite. Dans cette présentation, je vous propose de redécouvrir la programmation tacite, dans des contextes où c'est pertinent, permettant de mettre en avant **l'abstraction** pour **généraliser des comportements**. Découvrons ensemble le polymorphisme paramétrique, la variance (ou polarité) et la très amusante famille des profoncteurs et des _Arrows_ pour abstraire l'application de fonctions, permettant de traiter, génériquement, des objets qui ressemblent à des fonctions.
+La programmation fonctionnelle est souvent résumée à la manipulation de
+fonctions, que l'on peut passer en argument ou renvoyer. En somme, programmer
+avec des lambdas. Cette flexibilité de la manipulation de fonctions permet
+d'utiliser des opérateurs pour les composer, donnant lieu à un style de
+programmation que l'on appelle la "_programmation tacite_", ou "_point-free_",
+relativement populaire dans le monde Haskell, qui permet, malheureusement, très
+souvent, d'écrire des abominations, rendant le code illisible et
+**incroyablement complexe à raisonner** ! C'est pour cela que l'on lit très
+souvent qu'il n'y a pas de mérite à écrire des programmes dans ce style (et pour
+cause, une machine peut transformer du code _normal_ en _point-free_ et
+vice-versa).
+
+Pourtant, il arrive parfois que les outils que l'on veuille
+manipuler soient "_des genres de fonctions_, et que la grammaire du langage ne
+permette pas de les manipuler trivialement. L'utilisation d'un encodage
+similaire à la programmation tacite est l'utilisation de la méthode `.then`, en
+JavaScript, avant l'intégration des marqueurs `async/await`, dont le rôle était
+de palier l'expressivité du langage avec une approche abstraite. Dans cette
+présentation, je vous propose de redécouvrir la programmation tacite, dans des
+contextes où c'est pertinent, permettant de mettre en avant **l'abstraction**
+pour **généraliser des comportements**. Découvrons ensemble le polymorphisme
+paramétrique, la variance (ou polarité) et la très amusante famille des
+profoncteurs et des _Arrows_ pour abstraire l'application de fonctions,
+permettant de traiter, génériquement, des objets qui ressemblent à des
+fonctions.


### PR DESCRIPTION
## Description 
Create a new page for each talk. The name of the talk on the event page is clickable to access the page with details.

## Screenshot : 
![image](https://github.com/Fork-It-Community/forkit.community/assets/77801791/a9157dc8-1e56-43a1-847a-1b16c7fd7969)
![image](https://github.com/Fork-It-Community/forkit.community/assets/77801791/3e51656e-890c-4d31-b328-8a09793207cd)
![image](https://github.com/Fork-It-Community/forkit.community/assets/77801791/18bbb6ec-fb3a-49a1-8f96-55520ce6140f)
![image](https://github.com/Fork-It-Community/forkit.community/assets/77801791/04ecda99-bd13-4d44-b3ad-180320029abd)
