### PR TITLE
Add partners on event page and change padding on sponsor section

### DIFF
--- a/src/app/events/[slug]/page.tsx
+++ b/src/app/events/[slug]/page.tsx
@@ -9,6 +9,7 @@ import { Speakers } from "./speakers";
 import { Faq } from "./faq";
 import { Schedule } from "./schedule";
 import { Talks } from "./talks";
+import { Partners } from "@/app/(homepage)/partners";
 
 type EventPageProps = Readonly<{
   params: { slug: string };
@@ -90,6 +91,7 @@ export default async function EventPage({ params }: EventPageProps) {
           </div>
         )}
       <Sponsors event={event} />
+      <Partners />
       {event.prospectus &&
         event.prospectus.endDate &&
         new Date().getTime() <= event.prospectus.endDate.getTime() && (

--- a/src/app/events/[slug]/sponsors.tsx
+++ b/src/app/events/[slug]/sponsors.tsx
@@ -58,7 +58,7 @@ function SponsorImagePlaceholder(
 
 export function Sponsors(props: Readonly<{ event: Event }>) {
   return (
-    <div className="bg-white py-20 text-gray-900">
+    <div className="bg-white pt-20 text-gray-900">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto pb-4">
           <h2 className="font-heading text-4xl font-bold tracking-tight text-gray-800 sm:text-4xl md:text-4xl">


### PR DESCRIPTION
## Description 
Add the same partner section than the homepage on the event page. I removed the padding bottom of the sponsor section to reduce the gap between the 2 sections.

## Screenshots : 
![image](https://github.com/Fork-It-Community/forkit.community/assets/77801791/f98cff5f-4d3e-421b-ad7b-628a87b4d9b7)
![image](https://github.com/Fork-It-Community/forkit.community/assets/77801791/b1e1e777-a91d-455d-9570-b05a79d9abed)
