### PR TITLE
Fix: add padding on weekend guide

### DIFF
--- a/src/app/events/[slug]/weekend/page.tsx
+++ b/src/app/events/[slug]/weekend/page.tsx
@@ -286,7 +286,7 @@ export default function WeekendPage() {
               <Wine />
               Bars
             </h3>
-            <ul>
+            <ul className="md:pt-0.5">
               <li>Le Petit BAR Cocktails</li>
               <li>L’Absinthe (Cocktail)</li>
               <li>L’Antre du Malt (Bières craft)</li>


### PR DESCRIPTION
## Description : 
I added padding top to the bar list on md because the restaurants list is a grid, so the padding is not the same

## Screenshot
![image](https://github.com/Fork-It-Community/forkit.community/assets/77801791/5fc0e191-a44c-4072-835e-00dbf9c94c53)
