### PR TITLE
feat: add openfeedback links on schedule and talk pages

### DIFF
--- a/src/app/events/[slug]/schedule.tsx
+++ b/src/app/events/[slug]/schedule.tsx
@@ -9,6 +9,7 @@ import { match } from "ts-pattern";
 import { LanguageBadge } from "@/components/language-badge";
 import { FavoritesContextProvider } from "@/app/events/[slug]/contexts/FavoritesContext";
 import { FavoriteButton } from "@/components/favorite-button";
+import { FeedbackCTA } from "@/components/feedback-cta";
 
 function ScheduleComingSoon(props: Readonly<{ event: Event }>) {
   return (
@@ -228,21 +229,27 @@ export const ScheduleSection = (props: Readonly<{ event: Event }>) => {
   return (
     <div className="bg-gray-950">
       <div
-        className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-24 sm:py-32 lg:px-8"
+        className="mx-auto flex max-w-4xl flex-col gap-16 px-6 py-24 sm:py-32 lg:px-8"
         id="schedule"
       >
         <h2 className="text-center font-heading text-3xl font-bold tracking-tight text-white sm:text-4xl">
           Schedule
         </h2>
         <Schedule event={props.event} />
-        <div className="flex flex-col items-end justify-end gap-2">
+
+        <p className="text-center">
+          You can find a{" "}
           <Link
             href={`/events/${props.event.metadata.slug}/schedule`}
-            className="underline"
+            className="underline hover:no-underline"
           >
-            Dedicated schedule page
-          </Link>
-        </div>
+            dedicated schedule page
+          </Link>{" "}
+          for easier consultation for the big day.
+        </p>
+        {props.event.feedback && (
+          <FeedbackCTA href={props.event.feedback.link} />
+        )}
       </div>
     </div>
   );

--- a/src/app/events/[slug]/schedule.tsx
+++ b/src/app/events/[slug]/schedule.tsx
@@ -235,12 +235,23 @@ export const ScheduleSection = (props: Readonly<{ event: Event }>) => {
           Schedule
         </h2>
         <Schedule event={props.event} />
-        <Link
-          href={`/events/${props.event.metadata.slug}/schedule`}
-          className="justify-end text-right underline"
-        >
-          Dedicated schedule page
-        </Link>
+        <div className="flex flex-col items-end gap-2 md:flex-row md:justify-between">
+          {props.event.openfeedbackLink && (
+            <Link
+              href={props.event.openfeedbackLink}
+              className="underline"
+              target="_blank"
+            >
+              Give us feedback!
+            </Link>
+          )}
+          <Link
+            href={`/events/${props.event.metadata.slug}/schedule`}
+            className="underline"
+          >
+            Dedicated schedule page
+          </Link>
+        </div>
       </div>
     </div>
   );

--- a/src/app/events/[slug]/schedule.tsx
+++ b/src/app/events/[slug]/schedule.tsx
@@ -235,16 +235,7 @@ export const ScheduleSection = (props: Readonly<{ event: Event }>) => {
           Schedule
         </h2>
         <Schedule event={props.event} />
-        <div className="flex flex-col items-end gap-2 md:flex-row md:justify-between">
-          {props.event.openfeedbackLink && (
-            <Link
-              href={props.event.openfeedbackLink}
-              className="underline"
-              target="_blank"
-            >
-              Give us feedback!
-            </Link>
-          )}
+        <div className="flex flex-col items-end justify-end gap-2">
           <Link
             href={`/events/${props.event.metadata.slug}/schedule`}
             className="underline"

--- a/src/app/events/[slug]/schedule/page.tsx
+++ b/src/app/events/[slug]/schedule/page.tsx
@@ -28,7 +28,7 @@ export default async function SchedulePage({ params }: SchedulePageProps) {
         {event.name}
       </h1>
       <div className="bg-gray-950">
-        <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-24 sm:py-32 lg:px-8">
+        <div className="mx-auto flex max-w-4xl flex-col gap-16 px-6 py-24 sm:py-32 lg:px-8">
           <Schedule event={event} />
           {event.feedback && <FeedbackCTA href={event.feedback.link} />}
         </div>

--- a/src/app/events/[slug]/schedule/page.tsx
+++ b/src/app/events/[slug]/schedule/page.tsx
@@ -1,7 +1,7 @@
 import collections from "@/content/collections";
 import { Schedule } from "../schedule";
 import { formatDateTime } from "@/lib/utils";
-import Link from "next/link";
+import { FeedbackCTA } from "@/components/feedback-cta";
 
 type SchedulePageProps = Readonly<{
   params: { slug: string };
@@ -30,15 +30,7 @@ export default async function SchedulePage({ params }: SchedulePageProps) {
       <div className="bg-gray-950">
         <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-24 sm:py-32 lg:px-8">
           <Schedule event={event} />
-          {event.openfeedbackLink && (
-            <Link
-              href={event.openfeedbackLink}
-              className="underline"
-              target="_blank"
-            >
-              Give us feedback!
-            </Link>
-          )}
+          {event.feedback && <FeedbackCTA href={event.feedback.link} />}
         </div>
       </div>
     </div>

--- a/src/app/events/[slug]/schedule/page.tsx
+++ b/src/app/events/[slug]/schedule/page.tsx
@@ -1,6 +1,7 @@
 import collections from "@/content/collections";
 import { Schedule } from "../schedule";
 import { formatDateTime } from "@/lib/utils";
+import Link from "next/link";
 
 type SchedulePageProps = Readonly<{
   params: { slug: string };
@@ -29,6 +30,15 @@ export default async function SchedulePage({ params }: SchedulePageProps) {
       <div className="bg-gray-950">
         <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-24 sm:py-32 lg:px-8">
           <Schedule event={event} />
+          {event.openfeedbackLink && (
+            <Link
+              href={event.openfeedbackLink}
+              className="underline"
+              target="_blank"
+            >
+              Give us feedback!
+            </Link>
+          )}
         </div>
       </div>
     </div>

--- a/src/app/events/[slug]/talks/[talk]/page.tsx
+++ b/src/app/events/[slug]/talks/[talk]/page.tsx
@@ -8,7 +8,7 @@ import { FavoritesContextProvider } from "../../contexts/FavoritesContext";
 import { FavoriteButton } from "@/components/favorite-button";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
-import { MessageCircleMore } from "lucide-react";
+import { ExternalLink, MessageCircleMore } from "lucide-react";
 
 type TalkPageProps = Readonly<{
   params: { talk: string; slug: string };
@@ -58,44 +58,22 @@ export default async function TalkPage({ params }: TalkPageProps) {
 
           <div className="flex flex-row items-center justify-between">
             <LanguageBadge language={talk.language} />
-            {talk.openfeedbackLink && (
-              <Button
-                asChild
-                variant="outline"
-                size="sm"
-                className="hidden sm:flex"
-              >
+
+            {talk.feedback && (
+              <Button asChild variant="linkWhite" size="sm">
                 <Link
-                  href={talk.openfeedbackLink}
+                  href={talk.feedback.link}
                   className="flex gap-2"
                   target="_blank"
                 >
-                  <MessageCircleMore />
-                  Give us feedback!
+                  Give talk feedback!
+                  <ExternalLink className="h-4 w-4" />
                 </Link>
               </Button>
             )}
-            {talk.openfeedbackLink && (
-              <Button asChild variant="outline" size="sm" className="sm:hidden">
-                <Link href={talk.openfeedbackLink} target="_blank">
-                  <MessageCircleMore />
-                </Link>
-              </Button>
-            )}
-            <FavoriteButton
-              talkSlug={talk.metadata.slug}
-              size="sm"
-              className="hidden sm:flex"
-            />
-            <FavoriteButton
-              talkSlug={talk.metadata.slug}
-              isIconButton
-              size="sm"
-              className="sm:hidden"
-            />
           </div>
 
-          <div className="flex flex-col gap-4  pb-8">
+          <div className="flex flex-col gap-4 pb-8">
             {speakers.map((speaker) => (
               <div className="flex flex-row gap-4" key={speaker.metadata.slug}>
                 <Image
@@ -135,6 +113,19 @@ export default async function TalkPage({ params }: TalkPageProps) {
                 </div>
               </div>
             ))}
+          </div>
+          <div className="flex flex-row items-center justify-end">
+            <FavoriteButton
+              talkSlug={talk.metadata.slug}
+              size="sm"
+              className="hidden sm:flex"
+            />
+            <FavoriteButton
+              talkSlug={talk.metadata.slug}
+              isIconButton
+              size="sm"
+              className="sm:hidden"
+            />
           </div>
         </div>
       </div>

--- a/src/app/events/[slug]/talks/[talk]/page.tsx
+++ b/src/app/events/[slug]/talks/[talk]/page.tsx
@@ -8,7 +8,7 @@ import { FavoritesContextProvider } from "../../contexts/FavoritesContext";
 import { FavoriteButton } from "@/components/favorite-button";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
-import { ExternalLink, MessageCircleMore } from "lucide-react";
+import { ExternalLink } from "lucide-react";
 
 type TalkPageProps = Readonly<{
   params: { talk: string; slug: string };
@@ -56,24 +56,35 @@ export default async function TalkPage({ params }: TalkPageProps) {
             <Content />
           </div>
 
-          <div className="flex flex-row items-center justify-between">
+          <div className="flex flex-col justify-between gap-8 sm:flex-row sm:items-center">
             <LanguageBadge language={talk.language} />
-
-            {talk.feedback && (
-              <Button asChild variant="linkWhite" size="sm">
-                <Link
-                  href={talk.feedback.link}
-                  className="flex gap-2"
-                  target="_blank"
+            <div className="flex flex-row items-center justify-between gap-4">
+              {talk.feedback && (
+                <Button
+                  asChild
+                  variant="outline"
+                  size="sm"
+                  className="w-full sm:w-fit"
                 >
-                  Give talk feedback!
-                  <ExternalLink className="h-4 w-4" />
-                </Link>
-              </Button>
-            )}
+                  <Link
+                    href={talk.feedback.link}
+                    className="flex gap-2"
+                    target="_blank"
+                  >
+                    Give feedback!
+                    <ExternalLink className="h-4 w-4" />
+                  </Link>
+                </Button>
+              )}
+              <FavoriteButton
+                talkSlug={talk.metadata.slug}
+                size="sm"
+                className="w-full sm:w-fit"
+              />
+            </div>
           </div>
 
-          <div className="flex flex-col gap-4 pb-8">
+          <div className="flex flex-col gap-4 pb-16">
             {speakers.map((speaker) => (
               <div className="flex flex-row gap-4" key={speaker.metadata.slug}>
                 <Image
@@ -113,19 +124,6 @@ export default async function TalkPage({ params }: TalkPageProps) {
                 </div>
               </div>
             ))}
-          </div>
-          <div className="flex flex-row items-center justify-end">
-            <FavoriteButton
-              talkSlug={talk.metadata.slug}
-              size="sm"
-              className="hidden sm:flex"
-            />
-            <FavoriteButton
-              talkSlug={talk.metadata.slug}
-              isIconButton
-              size="sm"
-              className="sm:hidden"
-            />
           </div>
         </div>
       </div>

--- a/src/app/events/[slug]/talks/[talk]/page.tsx
+++ b/src/app/events/[slug]/talks/[talk]/page.tsx
@@ -6,6 +6,9 @@ import { ICONS } from "@/components/icons";
 import { LanguageBadge } from "@/components/language-badge";
 import { FavoritesContextProvider } from "../../contexts/FavoritesContext";
 import { FavoriteButton } from "@/components/favorite-button";
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+import { MessageCircleMore } from "lucide-react";
 
 type TalkPageProps = Readonly<{
   params: { talk: string; slug: string };
@@ -55,6 +58,30 @@ export default async function TalkPage({ params }: TalkPageProps) {
 
           <div className="flex flex-row items-center justify-between">
             <LanguageBadge language={talk.language} />
+            {talk.openfeedbackLink && (
+              <Button
+                asChild
+                variant="outline"
+                size="sm"
+                className="hidden sm:flex"
+              >
+                <Link
+                  href={talk.openfeedbackLink}
+                  className="flex gap-2"
+                  target="_blank"
+                >
+                  <MessageCircleMore />
+                  Give us feedback!
+                </Link>
+              </Button>
+            )}
+            {talk.openfeedbackLink && (
+              <Button asChild variant="outline" size="sm" className="sm:hidden">
+                <Link href={talk.openfeedbackLink} target="_blank">
+                  <MessageCircleMore />
+                </Link>
+              </Button>
+            )}
             <FavoriteButton
               talkSlug={talk.metadata.slug}
               size="sm"

--- a/src/components/favorite-button.tsx
+++ b/src/components/favorite-button.tsx
@@ -47,9 +47,9 @@ export const FavoriteButton: FC<FavoriteButtonProps> = ({
     >
       <div className="flex items-center gap-2">
         {isFavorite ? (
-          <HeartOff className="h-6 w-6" />
+          <HeartOff className="h-4 w-4" />
         ) : (
-          <Heart className="h-6 w-6" />
+          <Heart className="h-4 w-4" />
         )}
         {!isIconButton &&
           (isFavorite ? "Remove from favorites" : "Add to favorites")}

--- a/src/components/feedback-cta.tsx
+++ b/src/components/feedback-cta.tsx
@@ -2,33 +2,33 @@ import { Button } from "@/components/ui/button";
 
 export function FeedbackCTA({ href }: Readonly<{ href: string }>) {
   return (
-    <a href={href} target="_blank" rel="noreferer">
+    <a href={href} target="_blank" rel="noreferer" className="group">
       <div className="relative isolate overflow-hidden rounded-3xl bg-gray-900 px-6 py-20 text-center shadow-2xl sm:px-16">
         <h2 className="mx-auto max-w-2xl text-3xl font-bold tracking-tight text-white sm:text-4xl">
           We need you!
         </h2>
         <p className="mx-auto mt-6 max-w-xl text-lg leading-8 text-gray-300">
-          Help speakers by giving them feedbacks about their talks.
+          Help speakers by giving them feedbacks about their talks
         </p>
         <div className="mt-10 flex items-center justify-center gap-x-6">
           <Button>Give talk feedback!</Button>
         </div>
         <svg
           viewBox="0 0 1024 1024"
-          className="absolute left-1/2 top-1/2 -z-10 h-[64rem] w-[64rem] -translate-x-1/2 [mask-image:radial-gradient(closest-side,white,transparent)]"
+          className="absolute left-1/2 top-1/2 -z-10 h-[64rem] w-[64rem] -translate-x-1/2 text-primary transition-all [mask-image:radial-gradient(closest-side,white,transparent)]  group-hover:-translate-y-8"
           aria-hidden="true"
         >
           <circle
             cx={512}
             cy={512}
             r={512}
-            fill="url(#827591b1-ce8c-4110-b064-7cb85a0b1217)"
+            fill="url(#primaryCircle)"
             fillOpacity="0.7"
           />
           <defs>
-            <radialGradient id="827591b1-ce8c-4110-b064-7cb85a0b1217">
-              <stop stopColor="#ebff0f" />
-              <stop offset={1} stopColor="#ebff0f" />
+            <radialGradient id="primaryCircle">
+              <stop stopColor="currentColor" />
+              <stop offset={1} stopColor="currentColor" />
             </radialGradient>
           </defs>
         </svg>

--- a/src/components/feedback-cta.tsx
+++ b/src/components/feedback-cta.tsx
@@ -1,0 +1,38 @@
+import { Button } from "@/components/ui/button";
+
+export function FeedbackCTA({ href }: Readonly<{ href: string }>) {
+  return (
+    <a href={href} target="_blank" rel="noreferer">
+      <div className="relative isolate overflow-hidden rounded-3xl bg-gray-900 px-6 py-20 text-center shadow-2xl sm:px-16">
+        <h2 className="mx-auto max-w-2xl text-3xl font-bold tracking-tight text-white sm:text-4xl">
+          We need you!
+        </h2>
+        <p className="mx-auto mt-6 max-w-xl text-lg leading-8 text-gray-300">
+          Help speakers by giving them feedbacks about their talks.
+        </p>
+        <div className="mt-10 flex items-center justify-center gap-x-6">
+          <Button>Give talk feedback!</Button>
+        </div>
+        <svg
+          viewBox="0 0 1024 1024"
+          className="absolute left-1/2 top-1/2 -z-10 h-[64rem] w-[64rem] -translate-x-1/2 [mask-image:radial-gradient(closest-side,white,transparent)]"
+          aria-hidden="true"
+        >
+          <circle
+            cx={512}
+            cy={512}
+            r={512}
+            fill="url(#827591b1-ce8c-4110-b064-7cb85a0b1217)"
+            fillOpacity="0.7"
+          />
+          <defs>
+            <radialGradient id="827591b1-ce8c-4110-b064-7cb85a0b1217">
+              <stop stopColor="#ebff0f" />
+              <stop offset={1} stopColor="#ebff0f" />
+            </radialGradient>
+          </defs>
+        </svg>
+      </div>
+    </a>
+  );
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -18,7 +18,7 @@ const buttonVariants = cva(
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
-        linkWhite: "text-white underline-offset-4 hover:underline",
+        linkWhite: "text-white underline-offset-4 underline hover:no-underline",
       },
       size: {
         default: "h-10 px-4 py-2",

--- a/src/content/collections.ts
+++ b/src/content/collections.ts
@@ -135,7 +135,11 @@ const collections = {
           duration: z.number().optional(),
         }),
       ),
-      openfeedbackLink: z.string().url().optional(),
+      feedback: z
+        .object({
+          link: z.string().url(),
+        })
+        .optional(),
     }),
   }),
   speaker: defineCollection({
@@ -168,7 +172,11 @@ const collections = {
       description: z.string().nullish(),
       speakers: z.string().array(),
       language: z.enum(["french", "english"]),
-      openfeedbackLink: z.string().url().optional(),
+      feedback: z
+        .object({
+          link: z.string().url(),
+        })
+        .optional(),
     }),
   }),
 } as const;

--- a/src/content/collections.ts
+++ b/src/content/collections.ts
@@ -135,6 +135,7 @@ const collections = {
           duration: z.number().optional(),
         }),
       ),
+      openfeedbackLink: z.string().url().optional(),
     }),
   }),
   speaker: defineCollection({
@@ -167,6 +168,7 @@ const collections = {
       description: z.string().nullish(),
       speakers: z.string().array(),
       language: z.enum(["french", "english"]),
+      openfeedbackLink: z.string().url().optional(),
     }),
   }),
 } as const;

--- a/src/content/event/2024-06-07-rouen.mdx
+++ b/src/content/event/2024-06-07-rouen.mdx
@@ -175,6 +175,7 @@ schedule:
     slug: et-si-on-reprenait-le-controle-de-notre-vie-privee-en-ligne
     startTime: 2024-06-07T18:25:00.000Z
     duration: 30
+openfeedbackLink: https://openfeedback.io/fork-it-community-rouen-2024/2024-06-07
 ---
 
 import { About } from "./2024-06-07-rouen/about";

--- a/src/content/event/2024-06-07-rouen.mdx
+++ b/src/content/event/2024-06-07-rouen.mdx
@@ -175,7 +175,8 @@ schedule:
     slug: et-si-on-reprenait-le-controle-de-notre-vie-privee-en-ligne
     startTime: 2024-06-07T18:25:00.000Z
     duration: 30
-openfeedbackLink: https://openfeedback.io/fork-it-community-rouen-2024/2024-06-07
+feedback:
+  link: https://openfeedback.io/fork-it-community-rouen-2024/2024-06-07
 ---
 
 import { About } from "./2024-06-07-rouen/about";

--- a/src/content/talk/chapter-lead-retour-dxp-apres-2-ans-de-mise-en-place-chez-bforbank.mdx
+++ b/src/content/talk/chapter-lead-retour-dxp-apres-2-ans-de-mise-en-place-chez-bforbank.mdx
@@ -3,6 +3,7 @@ title: "Chapter Lead : retour d’XP après 2 ans de mise en place chez BforBank
 speakers:
   - arnaud-mary
 language: french
+openfeedbackLink: https://openfeedback.io/fork-it-community-rouen-2024/2024-06-07/gBQNtXx1T23FGHhCOzlX
 ---
 
 Chez BforBank, on sort du plus gros refactoring de notre histoire… Et ça ne concernait pas le code. En l’espace d’un an, nous sommes passés d’une équipe solo à une quinzaine de Squads et de l’agilité at-scale. Facile ? Ou pas.

--- a/src/content/talk/chapter-lead-retour-dxp-apres-2-ans-de-mise-en-place-chez-bforbank.mdx
+++ b/src/content/talk/chapter-lead-retour-dxp-apres-2-ans-de-mise-en-place-chez-bforbank.mdx
@@ -3,7 +3,8 @@ title: "Chapter Lead : retour d’XP après 2 ans de mise en place chez BforBank
 speakers:
   - arnaud-mary
 language: french
-openfeedbackLink: https://openfeedback.io/fork-it-community-rouen-2024/2024-06-07/gBQNtXx1T23FGHhCOzlX
+feedback:
+  link: https://openfeedback.io/fork-it-community-rouen-2024/2024-06-07/gBQNtXx1T23FGHhCOzlX
 ---
 
 Chez BforBank, on sort du plus gros refactoring de notre histoire… Et ça ne concernait pas le code. En l’espace d’un an, nous sommes passés d’une équipe solo à une quinzaine de Squads et de l’agilité at-scale. Facile ? Ou pas.

--- a/src/content/talk/comment-on-a-decoupe-notre-legacy.mdx
+++ b/src/content/talk/comment-on-a-decoupe-notre-legacy.mdx
@@ -3,7 +3,8 @@ title: "Comment on a découpé notre legacy ?"
 speakers:
   - antoine-mazure
 language: french
-openfeedbackLink: https://openfeedback.io/fork-it-community-rouen-2024/2024-06-07/XsF0GdOYpnrXzVRVWIbZ
+feedback:
+  link: https://openfeedback.io/fork-it-community-rouen-2024/2024-06-07/XsF0GdOYpnrXzVRVWIbZ
 ---
 
 Vous arrivez sur une nouvelle mission et là, c'est le drame : c'est un bon vieux legacy mal découpé et vous n'y comprenez rien. Après quelques semaines, vous rêvez déjà d'une refonte.

--- a/src/content/talk/comment-on-a-decoupe-notre-legacy.mdx
+++ b/src/content/talk/comment-on-a-decoupe-notre-legacy.mdx
@@ -3,6 +3,7 @@ title: "Comment on a découpé notre legacy ?"
 speakers:
   - antoine-mazure
 language: french
+openfeedbackLink: https://openfeedback.io/fork-it-community-rouen-2024/2024-06-07/XsF0GdOYpnrXzVRVWIbZ
 ---
 
 Vous arrivez sur une nouvelle mission et là, c'est le drame : c'est un bon vieux legacy mal découpé et vous n'y comprenez rien. Après quelques semaines, vous rêvez déjà d'une refonte.

--- a/src/content/talk/et-si-on-reprenait-le-controle-de-notre-vie-privee-en-ligne.mdx
+++ b/src/content/talk/et-si-on-reprenait-le-controle-de-notre-vie-privee-en-ligne.mdx
@@ -3,7 +3,8 @@ title: "Et si on reprenait le contrôle de notre vie privée en ligne ?"
 speakers:
   - clement-michel
 language: french
-openfeedbackLink: https://openfeedback.io/fork-it-community-rouen-2024/2024-06-07/hKZExavVn3KGwoVIW8Rq
+feedback:
+  link: https://openfeedback.io/fork-it-community-rouen-2024/2024-06-07/hKZExavVn3KGwoVIW8Rq
 ---
 
 Notre vie privée sur internet n'a jamais autant été mise à mal. Le business de la data opéré par les GAFAM, l'émmergence des "Data Brockers" ou encore les lois extra-territoriales (Cloud Act) sont tous de très bons exemples. Nous ferons donc un tour d'horizon de l'ensemble de ces menaces puis nous laisserons les sujets juridiques et géopolitiques aux personnes compétentes.

--- a/src/content/talk/et-si-on-reprenait-le-controle-de-notre-vie-privee-en-ligne.mdx
+++ b/src/content/talk/et-si-on-reprenait-le-controle-de-notre-vie-privee-en-ligne.mdx
@@ -3,6 +3,7 @@ title: "Et si on reprenait le contrôle de notre vie privée en ligne ?"
 speakers:
   - clement-michel
 language: french
+openfeedbackLink: https://openfeedback.io/fork-it-community-rouen-2024/2024-06-07/hKZExavVn3KGwoVIW8Rq
 ---
 
 Notre vie privée sur internet n'a jamais autant été mise à mal. Le business de la data opéré par les GAFAM, l'émmergence des "Data Brockers" ou encore les lois extra-territoriales (Cloud Act) sont tous de très bons exemples. Nous ferons donc un tour d'horizon de l'ensemble de ces menaces puis nous laisserons les sujets juridiques et géopolitiques aux personnes compétentes.

--- a/src/content/talk/how-to-make-your-open-source-project-popular.mdx
+++ b/src/content/talk/how-to-make-your-open-source-project-popular.mdx
@@ -3,7 +3,8 @@ title: "How to Make Your Open Source Project Popular"
 speakers:
   - andrey-sitnik
 language: english
-openfeedbackLink: https://openfeedback.io/fork-it-community-rouen-2024/2024-06-07/38GH3p4CustoJ5tAxFNi
+feedback:
+  link: https://openfeedback.io/fork-it-community-rouen-2024/2024-06-07/38GH3p4CustoJ5tAxFNi
 ---
 
 This talk summarizes my 15 years making open source tools. Some of them have become popular (PostCSS, Autoprefixer, and Nano ID have more than 60M downloads per month) but most projects did not (but their fails taught me more than the successful projects).

--- a/src/content/talk/how-to-make-your-open-source-project-popular.mdx
+++ b/src/content/talk/how-to-make-your-open-source-project-popular.mdx
@@ -3,6 +3,7 @@ title: "How to Make Your Open Source Project Popular"
 speakers:
   - andrey-sitnik
 language: english
+openfeedbackLink: https://openfeedback.io/fork-it-community-rouen-2024/2024-06-07/38GH3p4CustoJ5tAxFNi
 ---
 
 This talk summarizes my 15 years making open source tools. Some of them have become popular (PostCSS, Autoprefixer, and Nano ID have more than 60M downloads per month) but most projects did not (but their fails taught me more than the successful projects).

--- a/src/content/talk/il-est-difficile-de-faire-simple.mdx
+++ b/src/content/talk/il-est-difficile-de-faire-simple.mdx
@@ -3,7 +3,8 @@ title: "Il est difficile de faire simple"
 speakers:
   - olivier-huber
 language: french
-openfeedbackLink: https://openfeedback.io/fork-it-community-rouen-2024/2024-06-07/FnPOgXE8rht3dhgmlmTU
+feedback:
+  link: https://openfeedback.io/fork-it-community-rouen-2024/2024-06-07/FnPOgXE8rht3dhgmlmTU
 ---
 
 S’il se trouve un lien entre Richard Feynman et Léonard de Vinci en dehors de leur génie, c’est bien cette recherche de prioriser la simplicité.

--- a/src/content/talk/il-est-difficile-de-faire-simple.mdx
+++ b/src/content/talk/il-est-difficile-de-faire-simple.mdx
@@ -3,6 +3,7 @@ title: "Il est difficile de faire simple"
 speakers:
   - olivier-huber
 language: french
+openfeedbackLink: https://openfeedback.io/fork-it-community-rouen-2024/2024-06-07/FnPOgXE8rht3dhgmlmTU
 ---
 
 S’il se trouve un lien entre Richard Feynman et Léonard de Vinci en dehors de leur génie, c’est bien cette recherche de prioriser la simplicité.

--- a/src/content/talk/la-performance-web-le-cas-de-lafrique.mdx
+++ b/src/content/talk/la-performance-web-le-cas-de-lafrique.mdx
@@ -3,7 +3,8 @@ title: "La Performance Web : Le cas de l'Afrique"
 speakers:
   - ayoub-alouane
 language: french
-openfeedbackLink: https://openfeedback.io/fork-it-community-rouen-2024/2024-06-07/zCSGb2GD3afVZAZzn7u9
+feedback:
+  link: https://openfeedback.io/fork-it-community-rouen-2024/2024-06-07/zCSGb2GD3afVZAZzn7u9
 ---
 
 Nous partons souvent du principe que tout le monde dispose d'une bonne connexion Internet et d'un matériel informatique de haute spécification. Bien que cela puisse être vrai dans certaines régions, ce n'est pas le cas dans le monde entier. Je souhaite attirer l'attention sur l'Afrique, où de nombreux pays luttent contre de faibles connexions 3G coûteuses, en fonction de la quantité de données consommées. Ceci est dû à l'infrastructure limitée du continent, conduisant à une dépendance aux connexions mobiles.

--- a/src/content/talk/la-performance-web-le-cas-de-lafrique.mdx
+++ b/src/content/talk/la-performance-web-le-cas-de-lafrique.mdx
@@ -3,6 +3,7 @@ title: "La Performance Web : Le cas de l'Afrique"
 speakers:
   - ayoub-alouane
 language: french
+openfeedbackLink: https://openfeedback.io/fork-it-community-rouen-2024/2024-06-07/zCSGb2GD3afVZAZzn7u9
 ---
 
 Nous partons souvent du principe que tout le monde dispose d'une bonne connexion Internet et d'un matériel informatique de haute spécification. Bien que cela puisse être vrai dans certaines régions, ce n'est pas le cas dans le monde entier. Je souhaite attirer l'attention sur l'Afrique, où de nombreux pays luttent contre de faibles connexions 3G coûteuses, en fonction de la quantité de données consommées. Ceci est dû à l'infrastructure limitée du continent, conduisant à une dépendance aux connexions mobiles.

--- a/src/content/talk/le-pouvoir-des-choix-devenez-le-heros-de-votre-carriere.mdx
+++ b/src/content/talk/le-pouvoir-des-choix-devenez-le-heros-de-votre-carriere.mdx
@@ -4,7 +4,8 @@ speakers:
   - magali-de-labareyre
   - sebastien-ferrer
 language: french
-openfeedbackLink: https://openfeedback.io/fork-it-community-rouen-2024/2024-06-07/Oybedxyf0lEpgJhwaj4e
+feedback:
+  link: https://openfeedback.io/fork-it-community-rouen-2024/2024-06-07/Oybedxyf0lEpgJhwaj4e
 ---
 
 Une carrière est faite de choix et de circonstances. Si nous n’avons pas la main sur les circonstances, nous en avons chacun sur les choix que nous posons. Quitte à devoir faire des choix, autant poser ceux qui feront de notre vie professionnelle une aventure !

--- a/src/content/talk/le-pouvoir-des-choix-devenez-le-heros-de-votre-carriere.mdx
+++ b/src/content/talk/le-pouvoir-des-choix-devenez-le-heros-de-votre-carriere.mdx
@@ -4,6 +4,7 @@ speakers:
   - magali-de-labareyre
   - sebastien-ferrer
 language: french
+openfeedbackLink: https://openfeedback.io/fork-it-community-rouen-2024/2024-06-07/Oybedxyf0lEpgJhwaj4e
 ---
 
 Une carrière est faite de choix et de circonstances. Si nous n’avons pas la main sur les circonstances, nous en avons chacun sur les choix que nous posons. Quitte à devoir faire des choix, autant poser ceux qui feront de notre vie professionnelle une aventure !

--- a/src/content/talk/maintaining-an-open-source-library-for-Next-js-feedback-and-tips.mdx
+++ b/src/content/talk/maintaining-an-open-source-library-for-Next-js-feedback-and-tips.mdx
@@ -3,6 +3,7 @@ title: "Maintaining an open-source library for Next.js, feedback and tips"
 speakers:
   - francois-best
 language: english
+openfeedbackLink: https://openfeedback.io/fork-it-community-rouen-2024/2024-06-07/1W8YqrpIZMyd0djfkc9U
 ---
 
 The introduction of the app router and React Server Components in Next.js brings an extra challenge for open-source maintainers of libraries based on this framework.

--- a/src/content/talk/maintaining-an-open-source-library-for-Next-js-feedback-and-tips.mdx
+++ b/src/content/talk/maintaining-an-open-source-library-for-Next-js-feedback-and-tips.mdx
@@ -3,7 +3,8 @@ title: "Maintaining an open-source library for Next.js, feedback and tips"
 speakers:
   - francois-best
 language: english
-openfeedbackLink: https://openfeedback.io/fork-it-community-rouen-2024/2024-06-07/1W8YqrpIZMyd0djfkc9U
+feedback:
+  link: https://openfeedback.io/fork-it-community-rouen-2024/2024-06-07/1W8YqrpIZMyd0djfkc9U
 ---
 
 The introduction of the app router and React Server Components in Next.js brings an extra challenge for open-source maintainers of libraries based on this framework.

--- a/src/content/talk/microservices-maxi-supplice.mdx
+++ b/src/content/talk/microservices-maxi-supplice.mdx
@@ -4,7 +4,8 @@ speakers:
   - alexis-stefanski
   - yann-jacquot
 language: french
-openfeedbackLink: https://openfeedback.io/fork-it-community-rouen-2024/2024-06-07/pBIyCOCfsDUq9UTHyi8M
+feedback:
+  link: https://openfeedback.io/fork-it-community-rouen-2024/2024-06-07/pBIyCOCfsDUq9UTHyi8M
 ---
 
 Sur notre projet, comme souvent, la dette technique a commencé au jour 1.

--- a/src/content/talk/microservices-maxi-supplice.mdx
+++ b/src/content/talk/microservices-maxi-supplice.mdx
@@ -4,6 +4,7 @@ speakers:
   - alexis-stefanski
   - yann-jacquot
 language: french
+openfeedbackLink: https://openfeedback.io/fork-it-community-rouen-2024/2024-06-07/pBIyCOCfsDUq9UTHyi8M
 ---
 
 Sur notre projet, comme souvent, la dette technique a commencé au jour 1.

--- a/src/content/talk/migrer-de-drupal-7-a-drupal-10.mdx
+++ b/src/content/talk/migrer-de-drupal-7-a-drupal-10.mdx
@@ -3,7 +3,8 @@ title: "Migrer de Drupal 7 à Drupal 10"
 speakers:
   - frederic-bisson
 language: french
-openfeedbackLink: https://openfeedback.io/fork-it-community-rouen-2024/2024-06-07/ihUCoRfc4cjbOKdLP6ng
+feedback:
+  link: https://openfeedback.io/fork-it-community-rouen-2024/2024-06-07/ihUCoRfc4cjbOKdLP6ng
 ---
 
 Drupal 7 aura été supporté 14 ans (2011-2025). Cette version se permet de battre le record de longévité de Windows XP !

--- a/src/content/talk/migrer-de-drupal-7-a-drupal-10.mdx
+++ b/src/content/talk/migrer-de-drupal-7-a-drupal-10.mdx
@@ -3,6 +3,7 @@ title: "Migrer de Drupal 7 à Drupal 10"
 speakers:
   - frederic-bisson
 language: french
+openfeedbackLink: https://openfeedback.io/fork-it-community-rouen-2024/2024-06-07/ihUCoRfc4cjbOKdLP6ng
 ---
 
 Drupal 7 aura été supporté 14 ans (2011-2025). Cette version se permet de battre le record de longévité de Windows XP !

--- a/src/content/talk/tropical-software-developper-un-logiciel-pour-un-ministere-dasie-du-sud-est.mdx
+++ b/src/content/talk/tropical-software-developper-un-logiciel-pour-un-ministere-dasie-du-sud-est.mdx
@@ -3,7 +3,8 @@ title: "Tropical software: développer un logiciel pour un ministère d’Asie d
 speakers:
   - sylvain-dorey
 language: french
-openfeedbackLink: https://openfeedback.io/fork-it-community-rouen-2024/2024-06-07/8ViXNyZN6x3Xi4OogAeC
+feedback:
+  link: https://openfeedback.io/fork-it-community-rouen-2024/2024-06-07/8ViXNyZN6x3Xi4OogAeC
 ---
 
 De 2019 à maintenant, j’ai été impliqué dans le développement d’un système de gestion de la maintenance des ponts du Laos. C’est l’histoire de ce logiciel, dans ce contexte particulier de début de digitalisation d’un gouvernement et de collecte de données offline.

--- a/src/content/talk/tropical-software-developper-un-logiciel-pour-un-ministere-dasie-du-sud-est.mdx
+++ b/src/content/talk/tropical-software-developper-un-logiciel-pour-un-ministere-dasie-du-sud-est.mdx
@@ -3,6 +3,7 @@ title: "Tropical software: développer un logiciel pour un ministère d’Asie d
 speakers:
   - sylvain-dorey
 language: french
+openfeedbackLink: https://openfeedback.io/fork-it-community-rouen-2024/2024-06-07/8ViXNyZN6x3Xi4OogAeC
 ---
 
 De 2019 à maintenant, j’ai été impliqué dans le développement d’un système de gestion de la maintenance des ponts du Laos. C’est l’histoire de ce logiciel, dans ce contexte particulier de début de digitalisation d’un gouvernement et de collecte de données offline.

--- a/src/content/talk/une-ode-a-la-programmation-tacite.mdx
+++ b/src/content/talk/une-ode-a-la-programmation-tacite.mdx
@@ -3,6 +3,7 @@ title: "Une ode à la programmation tacite"
 speakers:
   - xavier-van-de-woestyne
 language: french
+openfeedbackLink: https://openfeedback.io/fork-it-community-rouen-2024/2024-06-07/Oyr3XFLeNJLLwyMDKKfa
 ---
 
 La programmation fonctionnelle est souvent résumée à la manipulation de

--- a/src/content/talk/une-ode-a-la-programmation-tacite.mdx
+++ b/src/content/talk/une-ode-a-la-programmation-tacite.mdx
@@ -3,7 +3,8 @@ title: "Une ode à la programmation tacite"
 speakers:
   - xavier-van-de-woestyne
 language: french
-openfeedbackLink: https://openfeedback.io/fork-it-community-rouen-2024/2024-06-07/Oyr3XFLeNJLLwyMDKKfa
+feedback:
+  link: https://openfeedback.io/fork-it-community-rouen-2024/2024-06-07/Oyr3XFLeNJLLwyMDKKfa
 ---
 
 La programmation fonctionnelle est souvent résumée à la manipulation de

--- a/src/content/talk/ux-design-through-the-eyes-of-an-architect.mdx
+++ b/src/content/talk/ux-design-through-the-eyes-of-an-architect.mdx
@@ -3,6 +3,7 @@ title: "UX Design through the eyes of an Architect"
 speakers:
   - alexandra-pituru
 language: english
+openfeedbackLink: https://openfeedback.io/fork-it-community-rouen-2024/2024-06-07/RKSoTn5WZYs7Fzcs5HIj
 ---
 
 In my 30-minute presentation, I'll discuss my transition from architecture to UX design. I'll explore the parallels between these fields and share the valuable lessons I've learned. I'll emphasize the importance of recognizing and utilizing the skills I already had in the new field.

--- a/src/content/talk/ux-design-through-the-eyes-of-an-architect.mdx
+++ b/src/content/talk/ux-design-through-the-eyes-of-an-architect.mdx
@@ -3,7 +3,8 @@ title: "UX Design through the eyes of an Architect"
 speakers:
   - alexandra-pituru
 language: english
-openfeedbackLink: https://openfeedback.io/fork-it-community-rouen-2024/2024-06-07/RKSoTn5WZYs7Fzcs5HIj
+feedback:
+  link: https://openfeedback.io/fork-it-community-rouen-2024/2024-06-07/RKSoTn5WZYs7Fzcs5HIj
 ---
 
 In my 30-minute presentation, I'll discuss my transition from architecture to UX design. I'll explore the parallels between these fields and share the valuable lessons I've learned. I'll emphasize the importance of recognizing and utilizing the skills I already had in the new field.


### PR DESCRIPTION
## Description 
Add a link to openfeedback on the schedule, the schedule page and the specific talk pages

## Screenshots : 
![image](https://github.com/Fork-It-Community/forkit.community/assets/77801791/749a08a8-2db1-49c1-bcc9-70b000abbe5b)
![image](https://github.com/Fork-It-Community/forkit.community/assets/77801791/034443c7-490f-406f-ae01-6ad1ed1ceecd)
![image](https://github.com/Fork-It-Community/forkit.community/assets/77801791/4f18c4de-103a-479b-acfb-54841cdc891c)
![image](https://github.com/Fork-It-Community/forkit.community/assets/77801791/2d4d571f-e147-4d78-9edb-a39aa88c6479)
![image](https://github.com/Fork-It-Community/forkit.community/assets/77801791/87d55b71-65df-4186-82b9-3f3865ece514)
