### PR TITLE
fix: remove scroll smooth and fix talk style

### DIFF
--- a/src/app/events/[slug]/talks.tsx
+++ b/src/app/events/[slug]/talks.tsx
@@ -41,7 +41,7 @@ async function Talk(props: Readonly<{ talk: { slug: string }; event: Event }>) {
                 />
               ))}
             </div>
-            <p className="flex-1 text-sm text-gray-300">
+            <p className="min-w-48 max-w-full flex-1 text-sm text-gray-300">
               {hosts.length ? (
                 <>
                   hosted by {hosts.map((host) => host.name).join(", ")} with{" "}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -38,10 +38,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html
-      lang="en"
-      className={cn(tomorrow.variable, inter.variable, "scroll-smooth")}
-    >
+    <html lang="en" className={cn(tomorrow.variable, inter.variable)}>
       <head>
         <link
           rel="apple-touch-icon"


### PR DESCRIPTION
## Description : 
Fix scroll smooth and fix display of the names when there is a lot of speaker in the talk section

## Screenshot : 

![image](https://github.com/Fork-It-Community/forkit.community/assets/77801791/c4a23cea-73fe-43a3-bb61-39395e5c10f3)
![image](https://github.com/Fork-It-Community/forkit.community/assets/77801791/5df90be7-f825-4995-8566-861ca763092b)
