### PR TITLE
fix : order of the talk for tunis meetup

### DIFF
--- a/src/content/meetup/2024-09-24-tunis.mdx
+++ b/src/content/meetup/2024-09-24-tunis.mdx
@@ -26,8 +26,8 @@ speakers:
   - idriss-neumann
   - sofiane-boukhris
 talks:
-  - concevoir-avec-efficacite
   - deployment-as-a-service
+  - concevoir-avec-efficacite
 schedule:
   - type: break
     name: Reception - 6:00 PM 


### PR DESCRIPTION
## Description : 
Change the order of the talks for the meetup in Tunis
## Before : 
![image](https://github.com/user-attachments/assets/158bcbde-f96c-451b-9c8e-fb39792b8c5d)
## After : 
![image](https://github.com/user-attachments/assets/af66b61f-4e5d-4b74-8b0a-b725a090ebc5)
