### PR TITLE
feat: add view transitions for spa-like navigation

### DIFF
--- a/src/components/MainPageTitle/index.astro
+++ b/src/components/MainPageTitle/index.astro
@@ -26,6 +26,7 @@ const { title, subtitle, imageSrc, blurImage } = Astro.props;
   <div class="flex flex-col items-center gap-2">
     <h1
       class="text-balance text-center font-heading text-3xl font-medium uppercase tracking-wider max-md:flex-1 md:text-5xl"
+      transition:name="page-title"
     >
       {title}
     </h1>

--- a/src/layouts/RootLayout.astro
+++ b/src/layouts/RootLayout.astro
@@ -1,15 +1,15 @@
 ---
+import { ClientRouter } from "astro:transitions";
 import Analytics from "@vercel/analytics/astro";
 import "@fontsource/tomorrow/400.css";
 import "@fontsource/tomorrow/500.css";
-import "@fontsource-variable/inter";
 import "@fontsource-variable/inter";
 import "@/styles/globals.css";
 import EnvHint from "@/components/EnvHint/EnvHint.astro";
 import { Toaster } from "@/components/ui/sonner";
 ---
 
-<html lang="en" class="dark">
+<html lang="en" class="dark" transition:animate="none">
   <head>
     <meta charset="utf-8" />
     <meta
@@ -31,6 +31,7 @@ import { Toaster } from "@/components/ui/sonner";
     />
     <meta name="generator" content={Astro.generator} />
     <meta name="theme-color" content="#171717" />
+    <ClientRouter />
     <slot name="seo" />
     <slot name="ld+json" />
   </head>


### PR DESCRIPTION
**Changes**
- Added `<ClientRouter />` component to RootLayout
- Set up transition animations for key elements
- Ensured backward compatibility for browsers that don't support View Transitions

Close: #280 