### PR TITLE
feat: add acast embed support for podcast episodes

### DIFF
--- a/src/pages/podcasts/[id]/episodes/[episode]/index.astro
+++ b/src/pages/podcasts/[id]/episodes/[episode]/index.astro
@@ -59,6 +59,20 @@ const ogImage = new URL(
   Astro.url.pathname + "/assets/og-image.jpg",
   Astro.site,
 );
+
+const acastUrl = (episode.data.urls || []).find((url) =>
+  url.url.includes("open.acast.com"),
+)?.url;
+
+let acastEmbedId = null;
+if (acastUrl) {
+  const acastMatch = acastUrl.match(
+    /\/public\/streams\/([^\/]+)\/episodes\/([^\.]+)/,
+  );
+  if (acastMatch && acastMatch.length === 3) {
+    acastEmbedId = `${acastMatch[1]}/${acastMatch[2]}`;
+  }
+}
 ---
 
 <MainLayout>
@@ -183,6 +197,21 @@ const ogImage = new URL(
 
   <div class="mx-auto w-full max-w-screen-sm px-4 py-8">
     <div class="flex flex-col gap-8 pb-32">
+      {
+        acastEmbedId && (
+          <div class="mb-8">
+            <iframe
+              title="Podcast Episode"
+              width="100%"
+              height="188px"
+              src={`https://embed.acast.com/${acastEmbedId}`}
+              scrolling="no"
+              frameBorder="0"
+              style="border:none;overflow:hidden;"
+            />
+          </div>
+        )
+      }
       <div lang={lang(episode.data.language)}>
         <Prose>
           <Content />

--- a/src/pages/podcasts/[id]/episodes/[episode]/index.astro
+++ b/src/pages/podcasts/[id]/episodes/[episode]/index.astro
@@ -205,8 +205,6 @@ if (acastUrl) {
               width="100%"
               height="188px"
               src={`https://embed.acast.com/${acastEmbedId}`}
-              scrolling="no"
-              frameBorder="0"
               style="border:none;overflow:hidden;"
             />
           </div>


### PR DESCRIPTION
**Changes**
- Added functionality to detect Acast podcast URLs in episode metadata
- Automatically extracts podcast and episode IDs from Acast stream URLs
- Displays an embedded Acast player above the episode content when available
- Works with both MP3 and M4A audio formats
- Maintains backward compatibility with episodes without Acast links

Close: #243 