### PR TITLE
fix: rollback client router (PR #281)

### DIFF
--- a/src/components/MainPageTitle/index.astro
+++ b/src/components/MainPageTitle/index.astro
@@ -26,7 +26,6 @@ const { title, subtitle, imageSrc, blurImage } = Astro.props;
   <div class="flex flex-col items-center gap-2">
     <h1
       class="text-balance text-center font-heading text-3xl font-medium uppercase tracking-wider max-md:flex-1 md:text-5xl"
-      transition:name="page-title"
     >
       {title}
     </h1>

--- a/src/layouts/RootLayout.astro
+++ b/src/layouts/RootLayout.astro
@@ -1,5 +1,4 @@
 ---
-import { ClientRouter } from "astro:transitions";
 import Analytics from "@vercel/analytics/astro";
 import "@fontsource/tomorrow/400.css";
 import "@fontsource/tomorrow/500.css";
@@ -9,7 +8,7 @@ import EnvHint from "@/components/EnvHint/EnvHint.astro";
 import { Toaster } from "@/components/ui/sonner";
 ---
 
-<html lang="en" class="dark" transition:animate="none">
+<html lang="en" class="dark">
   <head>
     <meta charset="utf-8" />
     <meta
@@ -31,7 +30,6 @@ import { Toaster } from "@/components/ui/sonner";
     />
     <meta name="generator" content={Astro.generator} />
     <meta name="theme-color" content="#171717" />
-    <ClientRouter />
     <slot name="seo" />
     <slot name="ld+json" />
   </head>


### PR DESCRIPTION
Rollback the PR #281 (sorry @AntoineKM 😅)

Because this break the back buttons. With the client router we don't have a document.referrer and we cannot have the smart back button (history.back() if the document.referrer contains the website host).

The back button behavior (be able to keep the scroll position when clicking on back button with history.back) is more important than the smooth transitions for the UX.

If someone have an idea of how to keep the 2 behaviors, please tell us 🙏


