### PR TITLE
fix: maintain smart back button behavior with view transitions

### DIFF
--- a/src/components/BackButton/index.tsx
+++ b/src/components/BackButton/index.tsx
@@ -1,27 +1,39 @@
 import { Button } from "@/components/ui/button";
 import type { ReactNode } from "react";
 import { MdArrowBack } from "react-icons/md";
+import { useEffect, useState } from "react";
 
 export const BackButton = (props: {
   href: string;
   buttonLabel?: ReactNode;
   contextLabel?: ReactNode;
 }) => {
+  const [canGoBack, setCanGoBack] = useState(false);
+
+  useEffect(() => {
+    const checkBackNavigation = () => {
+      setCanGoBack(window.history.length > 1);
+    };
+
+    checkBackNavigation();
+    document.addEventListener("astro:page-load", checkBackNavigation);
+
+    return () => {
+      document.removeEventListener("astro:page-load", checkBackNavigation);
+    };
+  }, []);
+
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    if (canGoBack) {
+      e.preventDefault();
+      window.history.back();
+    }
+  };
+
   return (
     <div className="flex items-center gap-4">
       <Button asChild variant="secondary-dark" size="xs">
-        <a
-          href={props.href}
-          onClick={(e) => {
-            if (
-              window.history.length > 1 &&
-              document.referrer.indexOf(window.location.host) !== -1
-            ) {
-              e.preventDefault();
-              window.history.back();
-            }
-          }}
-        >
+        <a href={props.href} onClick={handleClick}>
           <MdArrowBack className="mr-2" /> {props.buttonLabel ?? "Back"}
         </a>
       </Button>

--- a/src/layouts/RootLayout.astro
+++ b/src/layouts/RootLayout.astro
@@ -1,4 +1,5 @@
 ---
+import { ClientRouter } from "astro:transitions";
 import Analytics from "@vercel/analytics/astro";
 import "@fontsource/tomorrow/400.css";
 import "@fontsource/tomorrow/500.css";
@@ -30,8 +31,23 @@ import { Toaster } from "@/components/ui/sonner";
     />
     <meta name="generator" content={Astro.generator} />
     <meta name="theme-color" content="#171717" />
+    <ClientRouter />
     <slot name="seo" />
     <slot name="ld+json" />
+
+    <script>
+      document.addEventListener(
+        "astro:page-load",
+        () => {
+          document.documentElement.dataset.previousUrl = window.location.href;
+
+          window.addEventListener("popstate", () => {
+            document.documentElement.dataset.previousUrl = window.location.href;
+          });
+        },
+        { once: true },
+      );
+    </script>
   </head>
   <body
     class="flex min-h-svh flex-col overflow-x-hidden overflow-y-scroll bg-black text-foreground"


### PR DESCRIPTION
Hey @ivan-dalmet, here is the fix, this implementation is less sexy than #281, but it makes sense to do it if it's only for the back button. The smart back button functionality now works correctly while still maintaining smooth transitions between pages.

**Changes**
- Added `<ClientRouter />` component to `RootLayout` for view transitions
- Updated `BackButton` component to work with client-side navigation
- Added navigation history tracking using standard History API