### PR TITLE
fix: correct city id reference in download filename

### DIFF
--- a/src/pages/events/[id]/assets/download.ts
+++ b/src/pages/events/[id]/assets/download.ts
@@ -37,7 +37,7 @@ export const GET: APIRoute = async ({ params, site }) => {
   return new Response(zip.toBuffer(), {
     headers: {
       "Content-Type": "application/zip",
-      "Content-Disposition": `attachment; filename="${event.data.date.getFullYear()}-${event.data._computed.country?.id}-${event.data.city}-assets-${dayjs().format("YYYYMMDDHHmmss")}.zip"`,
+      "Content-Disposition": `attachment; filename="${event.data.date.getFullYear()}-${event.data._computed.country?.id}-${event.data.city.id}-assets-${dayjs().format("YYYYMMDDHHmmss")}.zip"`,
     },
   });
 };

--- a/src/pages/events/[id]/assets/index.astro
+++ b/src/pages/events/[id]/assets/index.astro
@@ -89,7 +89,7 @@ const imagesSrc = getEventAssetsSources(event);
           allEvents.map((e) => (
             <a
               href={lunalink(ROUTES.events[":id"].assets.__path, {
-                id: event.id,
+                id: e.id,
               })}
               class={cn("p-1", e.id === event.id && "opacity-60")}
             >


### PR DESCRIPTION
**Changes**
- Fix event assets page navigation: clicking on other events now correctly navigates to their assets page
- Fix download zip filename: city name now displays correctly instead of `[object Object]`

Close: #357 