### PR TITLE
feat: remove speakers from event schema and get theme from talks in computed

### DIFF
--- a/src/content/events/2024-belgium-ottignies-louvain-la-neuve/index.mdx
+++ b/src/content/events/2024-belgium-ottignies-louvain-la-neuve/index.mdx
@@ -14,9 +14,6 @@ image:
   media: "./ottignies-louvain-la-neuve.jpg"
   alt: "Ottignies-Louvain-la-Neuve"
   credit: EmDee on Wikipedia
-speakers:
-  - alexandra-pituru
-  - luis-rubiera
 coOrganizers:
   - pod
 schedule:

--- a/src/content/events/2024-france-rouen/index.mdx
+++ b/src/content/events/2024-france-rouen/index.mdx
@@ -64,25 +64,6 @@ sponsors:
       - "lunch"
   - slug: village-by-ca
     level: LOGISTIC
-speakers:
-  - abdelkrim-marchani
-  - alexandra-pituru
-  - alexis-stefanski
-  - antoine-mazure
-  - arnaud-mary
-  - andrey-sitnik
-  - ayoub-alouane
-  - clement-michel
-  - francois-best
-  - frederic-bisson
-  - luis-rubiera
-  - magali-de-labareyre
-  - olivier-huber
-  - sebastien-ferrer
-  - sylvain-dorey
-  - tony-godin
-  - xavier-van-de-woestyne
-  - yann-jacquot
 faq:
   - question: How many tickets are available for the event?
     answer: There is 50 early bird tickets and 200 tickets in total.

--- a/src/content/events/2024-malaisia-kuala-lumpur/index.mdx
+++ b/src/content/events/2024-malaisia-kuala-lumpur/index.mdx
@@ -17,9 +17,6 @@ image:
   credit: Izuddin Helmi Adnan
 tickets:
   link: https://lu.ma/1ibjrj38
-speakers:
-  - quentin-lerebours
-  - matthieu-mertens
 coOrganizers:
     - french-tech-malaysia
 organizers:

--- a/src/content/events/2024-morocco-casablanca/index.mdx
+++ b/src/content/events/2024-morocco-casablanca/index.mdx
@@ -14,11 +14,6 @@ image:
   media: "./casablanca.jpg"
   alt: "Hassan II Mosque, Casablanca, Morocco"
   credit: Mourad Saadi
-speakers:
-  - omar-borji
-  - elian-van-cutsem
-  - yoann-fleury
-  - ivan-dalmet
 coOrganizers:
   - bejs
   - docaposte

--- a/src/content/events/2024-thailand-bangkok/index.mdx
+++ b/src/content/events/2024-thailand-bangkok/index.mdx
@@ -24,10 +24,6 @@ organizers:
   - nhung-duong
   - yoann-fleury
   - quentin-lerebours
-speakers:
-  - jean-baptiste-briant
-  - kan-pawarisson
-  - ioun-nirach
 schedule:
   items:
     - type: info

--- a/src/content/events/2024-tunisia-tunis/index.mdx
+++ b/src/content/events/2024-tunisia-tunis/index.mdx
@@ -23,9 +23,6 @@ organizers:
   - aziz-ouertani
   - hend-fellah
   - idriss-neumann
-speakers:
-  - idriss-neumann
-  - sofiane-boukhris
 schedule:
   items:
     - type: info

--- a/src/content/events/2024-vietnam-da-nang/index.mdx
+++ b/src/content/events/2024-vietnam-da-nang/index.mdx
@@ -19,9 +19,6 @@ tickets:
 coOrganizers:
   - smart-dev
   - ace-coworking-space
-speakers:
-  - geert-theys
-  - quentin-lerebours
 organizers:
   - quentin-lerebours
 schedule:

--- a/src/content/events/2024-vietnam-hanoi/index.mdx
+++ b/src/content/events/2024-vietnam-hanoi/index.mdx
@@ -15,9 +15,6 @@ image:
   media: "./hanoi.jpg"
   alt: Tran Quoc Pagoda
   credit: Ben Koorengevel
-speakers:
-    - yoann-fleury
-    - vu-tuan-anh
 organizers:
   - yoann-fleury
   - rudy-baer

--- a/src/content/events/2025-france-montpellier/index.mdx
+++ b/src/content/events/2025-france-montpellier/index.mdx
@@ -15,10 +15,6 @@ image:
 coOrganizers:
   - mth-rvb
   - epitech
-speakers:
-  - alexandre-burgoni
-  - hugo-gresse
-  - roch-dardie
 organizers:
   - alexandra-pituru
 schedule:

--- a/src/content/events/2025-france-paris-meetup/index.mdx
+++ b/src/content/events/2025-france-paris-meetup/index.mdx
@@ -16,10 +16,6 @@ coOrganizers:
   - hymaia
   - neon
   - pigment
-speakers:
-  - gabriel-pichot
-  - david-gomes
-  - nicolas-dubien
 organizers:
   - yoann-fleury
   - ivan-dalmet

--- a/src/content/events/2025-malaysia-kuala-lumpur/index.mdx
+++ b/src/content/events/2025-malaysia-kuala-lumpur/index.mdx
@@ -16,19 +16,6 @@ coOrganizers:
   - 42-kl
 #prospectus:
 #  href: https://drive.google.com/file/d/1ZgxnpCFon9kv2p-LUsU4OX_XoAQNpy-C/view?usp=sharing
-speakers:
-  - omar-borji
-  - mohamed-rejeb
-  - rachid-zarouali
-  - eason-chai
-  - raihan-nismara
-  - vin-lim
-  - sylvain-dorey
-  - souhir-mkaouar
-  - erwan-rougeux
-  - hugo-perard
-  - hugo-siow
-  - kelvin-lai
 schedule:
   items:
     - type: info

--- a/src/content/events/2025-thailand-bangkok-2/index.mdx
+++ b/src/content/events/2025-thailand-bangkok-2/index.mdx
@@ -12,9 +12,6 @@ image:
   media: "./bangkok.jpg"
   alt: "Grand Palace, Bangkok, Thailand"
   credit: Alejandro Cartagena
-speakers:
-  - erez-david-shtayman
-  - marie-douet
 coOrganizers:
   - iglu
 tickets:

--- a/src/content/events/2025-thailand-bangkok-3/index.mdx
+++ b/src/content/events/2025-thailand-bangkok-3/index.mdx
@@ -13,9 +13,6 @@ image:
     media: "./bangkok.jpg"
     alt: "Grand Palace, Bangkok, Thailand"
     credit: Alejandro Cartagena
-speakers:
-  - erwan-rougeux
-  - matt-l
 coOrganizers:
   - iglu
 sponsors:

--- a/src/content/events/2025-thailand-bangkok/index.mdx
+++ b/src/content/events/2025-thailand-bangkok/index.mdx
@@ -19,9 +19,6 @@ coOrganizers:
   - french-tech-bangkok
 tickets:
   link: https://lu.ma/t3beyt7c
-speakers:
-  - adaku-nwakanma
-  - striebig-nicolas
 schedule:
   items:
     - type: info

--- a/src/content/events/2025-tunisia-nabeul/index.mdx
+++ b/src/content/events/2025-tunisia-nabeul/index.mdx
@@ -19,9 +19,6 @@ image:
   media: "dorsaf-sayeh-nabeul.jpeg"
   alt: "Nabeul"
   credit: Dorsaf Sayeh
-speakers:
-  - zouhair-mkassmi
-  - houssem-balti
 coOrganizers:
   - coworky
   - camelstudio

--- a/src/content/events/2025-tunisia-tunis-2/index.mdx
+++ b/src/content/events/2025-tunisia-tunis-2/index.mdx
@@ -19,9 +19,6 @@ coOrganizers:
   - camelstudio
   - the-digital-school
   - cwcloud
-speakers:
-  - omar-borji
-  - ahmed-ben-jbara
 organizers:
   - aziz-ouertani
   - hend-fellah

--- a/src/content/events/2025-tunisia-tunis/index.mdx
+++ b/src/content/events/2025-tunisia-tunis/index.mdx
@@ -51,19 +51,6 @@ eventStatus: EventScheduled
 attendanceMode: OfflineEventAttendanceMode
 prospectus:
   href: https://drive.google.com/drive/folders/1h7E9F-be0Bx11RYaZhvXAd73aKo26_47
-speakers:
-  - atef-maddouri
-  - idriss-neumann
-  - matthieu-coulon
-  - mohamed-ali-dridi
-  - mohamed-rejeb
-  - nabli-mohamed
-  - olivier-huber
-  - sonyth-huber
-  - souhir-mkaouar
-  - yassine-benabbas
-  - jihene-mejri
-  - elian-van-cutsem
 schedule:
   items:
     - type: info

--- a/src/content/events/2025-vietnam-hanoi/index.mdx
+++ b/src/content/events/2025-vietnam-hanoi/index.mdx
@@ -8,9 +8,6 @@ location:
   address: 7F, Detech Building, No, 8 Tôn Thất Thuyết, Str, Nam Từ Liêm, Hà Nội 100000, Vietnam
 coOrganizers:
   - twendee
-speakers:
-  - marie-douet
-  - vu-thai-duong
 schedule:
   items:
     - type: info

--- a/src/pages/events/[id].html.md/index.ts
+++ b/src/pages/events/[id].html.md/index.ts
@@ -30,7 +30,7 @@ ${event.data._computed.name} ${match(event.data.date)
       )
       .otherwise(
         () => "",
-      )} place on ${dayjs(event.data.date).format("DD/MM/YYYY")} to listen to ${event.data.speakers?.length ? `${event.data.speakers?.length} ` : ""}speakers at ${
+      )} place on ${dayjs(event.data.date).format("DD/MM/YYYY")} to listen to ${event.data._computed.speakers?.length ? `${event.data._computed.speakers?.length} ` : ""}speakers at ${
       event.data.location?.name
     }
 
@@ -93,9 +93,9 @@ ${(
 };
 
 const displaySpeakers = async (event: EventWithComputed) => {
-  if (!event.data.speakers) return "";
+  if (!event.data._computed.speakers) return "";
 
-  const speakers = await getEntries(event.data.speakers ?? []);
+  const speakers = await getEntries(event.data._computed.speakers ?? []);
 
   return `## Speakers
 

--- a/src/pages/events/[id]/index.astro
+++ b/src/pages/events/[id]/index.astro
@@ -57,7 +57,7 @@ export async function getStaticPaths() {
 const { event } = Astro.props;
 
 const partners = await getEntries(event.data.partners ?? []);
-const speakers = await getEntries(event.data.speakers ?? []);
+const speakers = await getEntries(event.data._computed.speakers ?? []);
 const coOrganizers = (await getEntries(event.data.coOrganizers ?? [])).filter(
   (p) => !!p,
 );

--- a/src/schemas/events.ts
+++ b/src/schemas/events.ts
@@ -116,12 +116,6 @@ const zEventBase = ({ image }: SchemaContext) =>
           }),
         )
         .optional(),
-      speakers: z
-        .array(reference("people"))
-        .optional()
-        .describe(
-          "Collection of people to be added in addition to the schedule",
-        ),
       eventStatus: z.enum([
         "EventCancelled",
         "EventMovedOnline",


### PR DESCRIPTION
The goal is to declare only schedule in event and not speakers and get them from talks. I have done all the related updates and remove the speakers from the events mdx