### PR TITLE
fork it for kids : open tickets url in a new tab

### DIFF
--- a/src/pages/fr/events/for-kids/[id]/index.astro
+++ b/src/pages/fr/events/for-kids/[id]/index.astro
@@ -167,6 +167,8 @@ const navItems = await getForKidsEventNavItems(forKidsEvent.id);
             <a
               href={forKidsEvent.data.tickets.link}
               class="flex items-center gap-1"
+              target="_blank"
+              rel="noreferrer"
             >
               {t("events:tickets.available")}
               <MdArrowForward className="group-hover:translate-x-1 transition" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ticket purchase links on the kids events page to open in a new tab while preserving referrer privacy protection, keeping your current page context intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->