### PR TITLE
chore: remove event vietnam location

### DIFF
--- a/src/content/events/2026-vietnam-hanoi/index.mdx
+++ b/src/content/events/2026-vietnam-hanoi/index.mdx
@@ -3,9 +3,6 @@ type: "event"
 city: hanoi
 date: 2026-03-07
 status: 'published'
-location:
-  name: Tòa Nhà Văn Hóa Ulis -Sunwah ĐH Ngoại Ngữ
-  address: 144 Đ. Xuân Thủy, Dịch Vọng Hậu, Cầu Giấy, Hà Nội, Viêt Nam
 image:
   media: "./cover.jpg"
   alt: "Hanoï, Viêt Nam"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Removed location information from the 2026 Vietnam Hanoi event listing. Venue details are no longer displayed for this event.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->