### PR TITLE
fix: cfp cover with no flag

### DIFF
--- a/src/generated-assets/components/CfpCoverNoFlag.tsx
+++ b/src/generated-assets/components/CfpCoverNoFlag.tsx
@@ -5,9 +5,22 @@ import {
 } from "@/generated-assets/image";
 import { COLORS } from "@/generated-assets/theme";
 import worldImage from "@/assets/images/world.png";
+import { getImage } from "astro:assets";
 
 export const CfpCoverNoFlag = async (props: { config: AssetImageConfig }) => {
-  const noFlagImage = await getAstroImageBase64(worldImage);
+  const worldImageResult = await getImage({
+    format: worldImage.format,
+    src: worldImage,
+  });
+
+  const defaultBackgroundImage = {
+    src: worldImageResult.src,
+    width: worldImage.width,
+    height: worldImage.height,
+    format: worldImage.format,
+  };
+
+  const noFlagImage = await getAstroImageBase64(defaultBackgroundImage);
 
   return (
     <div


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated image asset handling in the cover component to use asset metadata before generating base64 representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->