### PR TITLE
feat: add related events section on event page (#207)

### DIFF
--- a/src/components/RelatedEvents/index.astro
+++ b/src/components/RelatedEvents/index.astro
@@ -12,10 +12,10 @@ const { currentEvent, relatedEvents } = Astro.props;
 ---
 
 {
-  relatedEvents.length > 0 && (
+  relatedEvents.length > 0 && currentEvent.data._computed.city?.data.name && (
     <div class="relative mx-auto flex w-full max-w-screen-lg flex-col gap-8 px-4 py-12 md:py-24">
       <h2 class="scroll-mt-32 font-heading text-2xl font-medium uppercase tracking-widest">
-        More Events in {currentEvent.data._computed.city?.data.name}
+        More Events in {currentEvent.data._computed.city.data.name}
       </h2>
       <div class="grid gap-4 md:grid-cols-3">
         {relatedEvents.map((event) => (

--- a/src/pages/events/[id]/index.astro
+++ b/src/pages/events/[id]/index.astro
@@ -52,6 +52,7 @@ export async function getStaticPaths() {
         .filter(
           (e) =>
             e.id !== event.id &&
+            event.data._computed.city?.id !== undefined &&
             e.data._computed.city?.id === event.data._computed.city?.id &&
             (dayjs(e.data.date).isAfter(dayjs()) ||
               dayjs(e.data.date).isAfter(dayjs().subtract(30, "day"))),


### PR DESCRIPTION
From https://github.com/Fork-It-Community/forkit.community/pull/286

Changes

    Created a new RelatedEvents component that displays events in the same city
    Updated the event detail page to include the new component
    Implemented build-time filtering to pre-select related events
    Only passes necessary event data to each page, not the entire collection

Close: https://github.com/Fork-It-Community/forkit.community/issues/207

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a "More Events in [City]" section on individual event pages. Users can now discover related events in the same city, displayed in a responsive grid format with up to 3 event recommendations sorted by date.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->