### PR TITLE
fix : blured speakers on all events + make speakers clickable on for kids schedule

### DIFF
--- a/src/components/ForKidsEventSchedule/CardWorkshop.astro
+++ b/src/components/ForKidsEventSchedule/CardWorkshop.astro
@@ -1,5 +1,7 @@
 ---
 import SpeakerForCard from "@/components/Schedule/SpeakerForCard.astro";
+import { ROUTES } from "@/routes.gen";
+import { lunalink } from "@bearstudio/lunalink";
 import { Image } from "astro:assets";
 import { getEntries, render } from "astro:content";
 import { type CollectionEntry, getEntry } from "astro:content";
@@ -43,10 +45,17 @@ const animators = await getEntries(workshop.data.animators ?? []);
         {!!animators.length && (
           <div class="grid grid-cols-2 gap-3 md:grid-cols-3">
             {animators.map((animator) => (
-              <SpeakerForCard
-                name={animator.data.name}
-                avatar={animator.data.avatar ?? null}
-              />
+              <a
+                href={lunalink(ROUTES.people[":id"].__path, {
+                  id: animator.id,
+                })}
+                class="hover:underline"
+              >
+                <SpeakerForCard
+                  name={animator.data.name}
+                  avatar={animator.data.avatar ?? null}
+                />
+              </a>
             ))}
           </div>
         )}

--- a/src/components/Schedule/SpeakerForCard.astro
+++ b/src/components/Schedule/SpeakerForCard.astro
@@ -14,11 +14,10 @@ const { name, avatar, role } = Astro.props;
 
 <div class="flex items-center gap-2 sm:gap-3">
   <Image
-    class="aspect-square rounded-sm"
+    class="aspect-square w-10 rounded-sm"
     src={avatar ?? placeholder}
     alt={name}
-    width={40}
-    height={40}
+    width={250}
   />
   <div class="flex flex-col">
     <p


### PR DESCRIPTION
Closes #513 
---
## Before
<img width="1019" height="260" alt="image" src="https://github.com/user-attachments/assets/b3ad348a-b8f0-429a-afc2-6b29beb3a9bc" />
<img width="561" height="195" alt="image" src="https://github.com/user-attachments/assets/8b08855b-62b4-47ff-badb-c3a5e827edc9" />

## After 
<img width="1019" height="249" alt="image" src="https://github.com/user-attachments/assets/75c3c374-b936-4482-8d5e-55758fbb2602" />
<img width="921" height="317" alt="image" src="https://github.com/user-attachments/assets/332e62fc-95a1-4246-91ca-4423533ff6dd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Speaker and animator cards are now clickable, linking to their individual profile pages with hover styling to indicate interactivity.

* **UI/Style**
  * Adjusted speaker image sizing across components for improved visual presentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->