### PR TITLE
fix: update venue description ( vietnam event)

### DIFF
--- a/src/content/events/2026-vietnam-hanoi/index.mdx
+++ b/src/content/events/2026-vietnam-hanoi/index.mdx
@@ -62,4 +62,4 @@ After the success of our previous meetup in Hanoi and full-day events across Fra
 We're gathering developers, tech enthusiasts, and curious minds for a day of authentic talks, fresh perspectives, and real-world experiences shared by people shaping today's tech scene.
 You'll hear from both local and international speakers who will talk openly about their journeys : what worked, what didn't, and what they've learned along the way. Expect honest discussions, practical insights, and a community-driven atmosphere.
 
-Join us in Hanoi and be part of the Fork it! Community
+Join us in Hanoi and be part of the Fork it! Community.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated event page to announce Fork It! Hanoi 2026 — a full-day conference in March 2026 in partnership with Twendeesoft, targeting developers and tech enthusiasts, featuring local and international speakers, practical talks, and a community-driven atmosphere.
  * Removed previous Rouen 2024 content and the earlier emphasis on multilingual/international accessibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->