### PR TITLE
fix: update hero min height for for kids events

### DIFF
--- a/src/pages/fr/events/for-kids/[id]/index.astro
+++ b/src/pages/fr/events/for-kids/[id]/index.astro
@@ -97,7 +97,7 @@ const navItems = await getForKidsEventNavItems(forKidsEvent.id);
     }}
   />
   <div
-    class="relative flex h-[100svh] min-h-[600px] flex-col items-center justify-center"
+    class="relative flex h-[100svh] min-h-[900px] flex-col items-center justify-center"
   >
     <motion.div
       client:load


### PR DESCRIPTION
## Before : 
<img width="2318" height="1112" alt="image" src="https://github.com/user-attachments/assets/6ff77e63-0ada-446b-a017-728f71bc0603" />

## After : 
<img width="1285" height="798" alt="image" src="https://github.com/user-attachments/assets/c2605170-a230-4cee-9d8b-0e53a60d5e4d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted layout spacing on the events page for improved visual presentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->