### PR TITLE
feat: add internal linking

### DIFF
--- a/src/content/events/2026-tunisia-tunis/index.mdx
+++ b/src/content/events/2026-tunisia-tunis/index.mdx
@@ -38,8 +38,8 @@ partners:
 
 import { buttonVariants } from '@/components/ui/button'
 
-**Real talks, real experiences, real connections**. The <a href="https://www.forkit.community/events/2025-tunisia-tunis" target="_blank" rel="noopener noreferrer">previous Tunis full-day Fork It! event</a> has been a blast! We are hosting a new one in April 2026 at the Cité de la Culture, just 6
-weeks after <a href="https://www.forkit.community/events/2026-vietnam-hanoi" target="_blank" rel="noopener noreferrer">the full-day event in Hanoï</a>. Aiming to bring together professionals and creatives to share knowledge, learn from each other, and exchange ideas, around 200 participants will
+**Real talks, real experiences, real connections**. The [previous Tunis full-day Fork It! event](https://www.forkit.community/events/2025-tunisia-tunis) has been a blast! We are hosting a new one in April 2026 at the Cité de la Culture, just 6
+weeks after [the full-day event in Hanoï](https://www.forkit.community/events/2026-vietnam-hanoi). Aiming to bring together professionals and creatives to share knowledge, learn from each other, and exchange ideas, around 200 participants will
 be there.
 A diverse lineup of **international and local speakers**, the conference will feature dynamic presentations and discussions, offering practical insights and real-world experiences.
 

--- a/src/content/events/2026-vietnam-hanoi/index.mdx
+++ b/src/content/events/2026-vietnam-hanoi/index.mdx
@@ -62,7 +62,7 @@ partners:
 ---
 
 
-After the success of <a href="https://www.forkit.community/events/locations/vietnam/hanoi" target="_blank" rel="noopener noreferrer">our previous meetups in Hanoï</a> and full-day events across <a href="https://www.forkit.community/events/locations/france" target="_blank" rel="noopener noreferrer">France</a>, <a href="https://www.forkit.community/events/locations/tunisia" target="_blank" rel="noopener noreferrer">Tunisia</a>, and <a href="https://www.forkit.community/events/locations/malaysia" target="_blank" rel="noopener noreferrer">Malaysia</a>, Fork it! is coming back to Hanoï, Vietnam this March 2026 for a full-day conference in partnership with <a href="https://www.twendeesoft.com/" target="_blank" rel="noopener noreferrer">Twendeesoft</a>.
+After the success of [our previous meetups in Hanoï](https://www.forkit.community/events/locations/vietnam/hanoi) and full-day events across [France](https://www.forkit.community/events/locations/france), [Tunisia](https://www.forkit.community/events/locations/tunisia), and [Malaysia](https://www.forkit.community/events/locations/malaysia), Fork it! is coming back to Hanoï, Vietnam this March 2026 for a full-day conference in partnership with <a href="https://www.twendeesoft.com/" target="_blank" rel="noopener noreferrer">Twendeesoft</a>.
 
 We're gathering developers, tech enthusiasts, and curious minds for a day of authentic talks, fresh perspectives, and real-world experiences shared by people shaping today's tech scene.
 You'll hear from both local and international speakers who will talk openly about their journeys : what worked, what didn't, and what they've learned along the way. Expect honest discussions, practical insights, and a community-driven atmosphere.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Tunis and Hanoi event pages with richer, link‑enhanced content and cross-references.
  * Added event specifics: venue (Cité de la Culture), target ~200 participants, diverse international and local speakers, and multilingual sessions.
  * Improved calls to action (stronger emphasis/formatting) and standardized city naming for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->