### PR TITLE
fix : for kids logo url in explore the community

### DIFF
--- a/src/layouts/EventSubPageLayout.astro
+++ b/src/layouts/EventSubPageLayout.astro
@@ -32,7 +32,7 @@ const { event } = Astro.props;
       eventCity={event.data._computed.city?.data.name ?? ""}
       eventCountry={event.data._computed.country?.data.name ?? ""}
       eventDate={event.data.date}
-      logoUrl={lunalink(ROUTES.fr.events["for-kids"].__path, {})}
+      logoUrl={lunalink(ROUTES.__path, {})}
       pageUrl={new URL(Astro.url.pathname, Astro.site).toString()}
     />
   </div>

--- a/src/layouts/ForKidsEventSubPageLayout.astro
+++ b/src/layouts/ForKidsEventSubPageLayout.astro
@@ -32,7 +32,7 @@ const { forKidsEvent } = Astro.props;
       eventCity={forKidsEvent.data._computed.city?.data.name ?? ""}
       eventCountry={forKidsEvent.data._computed.country?.data.name ?? ""}
       eventDate={forKidsEvent.data.date}
-      logoUrl={lunalink(ROUTES.__path, {})}
+      logoUrl={lunalink(ROUTES.fr.events["for-kids"].__path, {})}
       pageUrl={new URL(Astro.url.pathname, Astro.site).toString()}
       type="for-kids"
     />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected logo URL resolution in for-kids event layouts to reference the appropriate French for-kids route path instead of the generic route path.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->