### PR TITLE
fix: remove duplicate speakers from event page

### DIFF
--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -7,7 +7,7 @@ import {
   type CollectionKey,
 } from "astro:content";
 import { match } from "ts-pattern";
-import { entries, isEmpty, isNonNullish, isNullish } from "remeda";
+import { entries, isEmpty, isNonNullish, isNullish, uniqueBy } from "remeda";
 import { lunalink } from "@bearstudio/lunalink";
 import { ROUTES } from "@/routes.gen";
 import defaultImage from "@/assets/images/events.jpeg";
@@ -154,7 +154,7 @@ export async function eventWithComputed<
         city,
         country,
         talks,
-        speakers,
+        speakers: uniqueBy(speakers, (speaker) => speaker.id),
         organizers,
         volunteers,
       },

--- a/src/pages/events/[id]/index.astro
+++ b/src/pages/events/[id]/index.astro
@@ -76,6 +76,7 @@ const { event, relatedEvents } = Astro.props;
 
 const partners = await getEntries(event.data.partners ?? []);
 const speakers = await getEntries(event.data._computed.speakers ?? []);
+
 const coOrganizers = (await getEntries(event.data.coOrganizers ?? [])).filter(
   (p) => !!p,
 );


### PR DESCRIPTION
Use uniqueBy to deduplicate speakers array based on speaker ID before rendering event page, preventing same speaker from appearing multiple times in the speakers section.

closes #589

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying event co-organizers on event pages.

* **Bug Fixes**
  * Fixed duplicate speaker entries appearing in event details.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->