### PR TITLE
feat: disable talk for now

### DIFF
--- a/src/content/events/2026-vietnam-hanoi/index.mdx
+++ b/src/content/events/2026-vietnam-hanoi/index.mdx
@@ -58,8 +58,9 @@ schedule:
       description: The second keynote of the day
     - type: conference
       slug: open-infrastructure-for-ai-era
-    - type: conference
-      slug: what-changes-when-current-security-practices-meet-the-blockchain
+    - type: info
+      name: More Talks
+      description: Afternoon talks with experts, then a quick coffee.
     - type: info
       name: Closing Speech
       description: Final words and thank you.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the 2026 Vietnam (Hanoi) event schedule: replaced a conference session with an information segment titled "More Talks" — "Afternoon talks with experts, then a quick coffee" — preserving its slot.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->