### PR TITLE
feat: add clever cloud as sponsor to Hanoi's event

### DIFF
--- a/src/content/events/2026-vietnam-hanoi/index.mdx
+++ b/src/content/events/2026-vietnam-hanoi/index.mdx
@@ -88,6 +88,8 @@ sponsors:
     level: BRONZE
   - slug: sutunam
     level: BRONZE
+  - slug: clever-cloud
+    level: BRONZE
 partners:
   - french-tech-vietnam
   - tao-startup


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added clever-cloud as a Bronze sponsor for the 2026 Vietnam Hanoi event.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->