### PR TITLE
feat: update talks order

### DIFF
--- a/src/content/events/2026-vietnam-hanoi/index.mdx
+++ b/src/content/events/2026-vietnam-hanoi/index.mdx
@@ -44,7 +44,7 @@ schedule:
       slug: shaping-symfony-8-shipping-symfony-8-lessons-from-the-inside
       startTime: 2026-03-07T10:15:00.000Z
     - type: conference
-      slug: from-vibe-coding-to-vibe-learning
+      slug: building-an-ai-company-creating-real-value-from-uncertain-technology
     - type: info
       name: Coffee Break
       description: Time for coffee and chatting with experts/speakers.
@@ -53,17 +53,14 @@ schedule:
     - type: info
       name: Lunch
       description: Have a good lunch and talk with others.
-    - type: info
-      name: Afternoon Keynote
-      description: The second keynote of the day
     - type: conference
       slug: what-changes-when-current-security-practices-meet-the-blockchain
-    - type: conference
-      slug: building-an-ai-company-creating-real-value-from-uncertain-technology
     - type: conference
       slug: one-dissatisfied-customer-led-me-to-redesign-web-design
     - type: conference
       slug: open-infrastructure-for-ai-era
+    - type: conference
+      slug: from-vibe-coding-to-vibe-learning
     - type: info
       name: More Talks
       description: Afternoon talks with experts, then a quick coffee.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the 2026 Vietnam Hanoi event schedule with reorganized sessions and removed the Afternoon Keynote entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->