### PR TITLE
fix : make link unclickable on conference card content

### DIFF
--- a/src/components/Conferences/ConferenceCard.astro
+++ b/src/components/Conferences/ConferenceCard.astro
@@ -68,6 +68,7 @@ const { Content } = await render(conference);
   }
   <div
     class="line-clamp-3 text-ellipsis [&_a]:pointer-events-none [&_a]:text-current [&_a]:no-underline"
+    inert
   >
     <Content />
   </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Conference cards now make only the title area clickable, improving click targets and visual feedback.
  * In-card body text and embedded links are no longer interactive, preventing accidental navigation from content snippets.
  * Layout adjustments preserve footer content while ensuring the card container and interactive region behave consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->