### PR TITLE
fix: registration still open when no no coOrganizers in the asset

### DIFF
--- a/src/pages/events/[id]/assets/_registration-still-open-insta.tsx
+++ b/src/pages/events/[id]/assets/_registration-still-open-insta.tsx
@@ -90,6 +90,7 @@ export function registrationStillOpenInsta(options: {
                   fontWeight: 500,
                   textTransform: "uppercase",
                   letterSpacing: 4,
+                  paddingTop: coOrganizersLogos.length ? 0 : 96,
                 }}
               >
                 Registrations are still open

--- a/src/pages/events/[id]/assets/_registration-still-open.tsx
+++ b/src/pages/events/[id]/assets/_registration-still-open.tsx
@@ -90,6 +90,7 @@ export function registrationStillOpen(options: {
                   fontWeight: 500,
                   textTransform: "uppercase",
                   letterSpacing: 4,
+                  paddingTop: coOrganizersLogos.length ? 0 : 60,
                 }}
               >
                 Registrations are still open


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed vertical spacing for "Registrations are still open" messaging when co-organizer logos are displayed or absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->