### PR TITLE
Add security headers (CSP, X-Content-Type-Options, X-Frame-Options)

### DIFF
--- a/src/lib/orejime/config.ts
+++ b/src/lib/orejime/config.ts
@@ -145,7 +145,13 @@ export function getOrejimeConfig(): Config {
         title: "Analytics",
         description:
           "We use Vercel Analytics and Clarity to understand how visitors navigate our website and identify areas for improvement. This helps us provide a better user experience.",
-        cookies: ["__vercel_live_token", "_vercel_jwt", "__va", "_clck", "_clsk"],
+        cookies: [
+          "__vercel_live_token",
+          "_vercel_jwt",
+          "__va",
+          "_clck",
+          "_clsk",
+        ],
       },
     ],
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,9 +1,29 @@
 import { changeLanguage, init } from "@/i18n";
 import { defineMiddleware } from "astro:middleware";
 
+const contentSecurityPolicy = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline' https://*.clarity.ms https://connect.facebook.net",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' https://img.youtube.com https://*.facebook.com data:",
+  "font-src 'self'",
+  "frame-src https://www.youtube.com https://embed.acast.com https://www.openstreetmap.org",
+  "connect-src 'self' https://*.clarity.ms https://*.facebook.com https://*.facebook.net",
+  "object-src 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "frame-ancestors 'none'",
+].join("; ");
+
 export const onRequest = defineMiddleware(async ({ currentLocale }, next) => {
   await init();
   changeLanguage(currentLocale);
 
-  return next();
+  const response = await next();
+
+  response.headers.set("Content-Security-Policy", contentSecurityPolicy);
+  response.headers.set("X-Content-Type-Options", "nosniff");
+  response.headers.set("X-Frame-Options", "DENY");
+
+  return response;
 });


### PR DESCRIPTION
## Summary

Configure three essential security headers to protect the site from XSS, MIME-sniffing, and clickjacking attacks:

- **Content-Security-Policy**: Restrict resource loading to same-origin with specific allowances for embedded content (YouTube, Acast, OpenStreetMap) and analytics services (Clarity, Meta Pixel)
- **X-Content-Type-Options**: Set to `nosniff` to prevent browsers from MIME-sniffing response payloads
- **X-Frame-Options**: Set to `DENY` to prevent the site from being embedded in iframes

Headers are set via Astro middleware, ensuring they apply to both Vercel and Node.js deployments.

## Test plan

- [x] Build succeeds with new middleware code
- [x] Verify headers are applied to all responses via browser DevTools Network tab
- [x] Test that embedded content (YouTube, Acast, maps) still loads correctly
- [x] Test that analytics (Clarity, Meta Pixel) still track correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Style**
- Reformatted analytics configuration array from single-line to multi-line format for improved readability.

**New Features**
- Strengthened application security by implementing additional protective headers in all HTTP responses. Added Content-Security-Policy, X-Content-Type-Options, and X-Frame-Options headers to provide enhanced defenses against common web-based vulnerabilities, including cross-site scripting, clickjacking, and MIME-type confusion attacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->