### PR TITLE
feat: remove noe from schedule and add duration

### DIFF
--- a/src/content/events/2026-vietnam-hanoi/index.mdx
+++ b/src/content/events/2026-vietnam-hanoi/index.mdx
@@ -42,9 +42,11 @@ schedule:
     - type: conference
       slug: shaping-symfony-8-shipping-symfony-8-lessons-from-the-inside
       startTime: 2026-03-07T10:15:00.000Z
+      duration: 45
     - type: conference
       slug: building-an-ai-company-creating-real-value-from-uncertain-technology
       startTime: 2026-03-07T11:00:00.000Z
+      duration: 30
     - type: info
       name: Coffee Break
       description: Time for coffee and chatting with experts/speakers.
@@ -52,6 +54,7 @@ schedule:
     - type: conference
       slug: modern-stack-for-old-books-engineering-a-digital-library-for-southeast-asian-history
       startTime: 2026-03-07T11:50:00.000Z
+      duration: 30
     - type: info
       name: Lunch
       description: Have a good lunch and talk with others.
@@ -59,34 +62,35 @@ schedule:
     - type: conference
       slug: digital-sovereignty-and-ai-the-strategic-cost-of-inaction
       startTime: 2026-03-07T13:50:00.000Z
+      duration: 30
     - type: conference
       slug: one-dissatisfied-customer-led-me-to-redesign-web-design
       startTime: 2026-03-07T14:20:00.000Z
+      duration: 45
     - type: conference
       slug: open-infrastructure-for-ai-era
       status: cancelled
       startTime: 2026-03-07T15:05:00.000Z
-    - type: conference
-      slug: how-to-use-ai-to-evolve-an-internal-react-library-adapting-to-workplace-realities
-      status: replacement
-      startTime: 2026-03-07T15:05:00.000Z
     - type: info
       name: Coffee Break
       description: Time for coffee and chatting with experts/speakers.
-      startTime: 2026-03-07T15:35:00.000Z
+      startTime: 2026-03-07T15:05:00.000Z
     - type: conference
       slug: what-changes-when-current-security-practices-meet-the-blockchain
-      startTime: 2026-03-07T15:55:00.000Z
+      startTime: 2026-03-07T15:25:00.000Z
+      duration: 30
     - type: conference
       slug: from-vibe-coding-to-vibe-learning
-      startTime: 2026-03-07T16:25:00.000Z
+      startTime: 2026-03-07T15:55:00.000Z
+      duration: 30
     - type: conference
       slug: the-ai-career-lift-leveraging-todays-ai-to-stay-relevant-and-outperform
-      startTime: 2026-03-07T16:55:00.000Z
+      startTime: 2026-03-07T16:25:00.000Z
+      duration: 30
     - type: info
       name: Closing Speech
       description: Final words and thank you.
-      startTime: 2026-03-07T17:25:00.000Z
+      startTime: 2026-03-07T16:55:00.000Z
     - type: info
       name: Networking cocktail
       description: Have a beer and share your experience


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated event schedule for the 2026 Vietnam Hanoi conference with new timing specifications
  * Added explicit durations to all schedule items for improved clarity
  * Revised session start times including breaks and talks to optimize the day's flow
  * Removed one conference session from the published schedule

<!-- end of auto-generated comment: release notes by coderabbit.ai -->