### PR TITLE
feat: reduce download assets images

### DIFF
--- a/src/assets/consts.ts
+++ b/src/assets/consts.ts
@@ -31,3 +31,8 @@ export const EXCLUDED_CATEGORIES_BY_TYPE: Record<
   meetup: ["cfp-", "banner"],
   event: [],
 };
+
+export const DOWNLOAD_EXCLUDED_CATEGORIES: AssetCategoryId[] = [
+  "banner",
+  "other",
+];

--- a/src/pages/events/[id]/assets/_utils.ts
+++ b/src/pages/events/[id]/assets/_utils.ts
@@ -1,4 +1,8 @@
-import { ASSET_CATEGORIES, EXCLUDED_CATEGORIES_BY_TYPE } from "@/assets/consts";
+import {
+  ASSET_CATEGORIES,
+  EXCLUDED_CATEGORIES_BY_TYPE,
+  type AssetCategoryId,
+} from "@/assets/consts";
 import { NotFoundAssetError } from "@/generated-assets/api";
 import { getImageNameFromTsxPath } from "@/generated-assets/image";
 import { eventWithComputed } from "@/lib/events";
@@ -90,13 +94,16 @@ const getOppositeSuffixes = (
 export const getGroupedAssets = (
   imagesSrc: string[],
   eventType: CollectionEntry<"events">["data"]["type"],
+  additionalExcludedCategories: AssetCategoryId[] = [],
 ) => {
   const oppositeSuffixes = getOppositeSuffixes(eventType);
   const groups = groupBy(imagesSrc, categorize);
+  const excluded = [
+    ...EXCLUDED_CATEGORIES_BY_TYPE[eventType],
+    ...additionalExcludedCategories,
+  ];
 
-  return ASSET_CATEGORIES.filter(
-    ({ id }) => !EXCLUDED_CATEGORIES_BY_TYPE[eventType].includes(id),
-  )
+  return ASSET_CATEGORIES.filter(({ id }) => !excluded.includes(id))
     .map((category) => ({
       ...category,
       images: (groups[category.id] ?? []).filter((src) => {

--- a/src/pages/events/[id]/assets/download.ts
+++ b/src/pages/events/[id]/assets/download.ts
@@ -1,4 +1,5 @@
-import { getEventAssetsSources } from "./_utils";
+import { getEventAssetsSources, getGroupedAssets } from "./_utils";
+import { DOWNLOAD_EXCLUDED_CATEGORIES } from "@/assets/consts";
 import type { APIRoute } from "astro";
 import { getEntry } from "astro:content";
 import dayjs from "dayjs";
@@ -16,7 +17,11 @@ export const GET: APIRoute = async ({ params, site }) => {
   const event = await eventWithComputed(eventEntry);
 
   const zip = new AdmZip();
-  const imagesSrc = getEventAssetsSources(event);
+  const imagesSrc = getGroupedAssets(
+    getEventAssetsSources(event),
+    event.data.type,
+    DOWNLOAD_EXCLUDED_CATEGORIES,
+  ).flatMap((group) => group.images);
 
   await Promise.all(
     imagesSrc.map(async (src) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Asset downloads now automatically exclude banner and other asset categories by default. This change refines the asset filtering mechanism, providing users with more targeted downloads when retrieving event assets. The exclusion logic is now more flexible and supports additional configurable category filters for future customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->