### PR TITLE
fix: small missing infos in RSS feeds 

### DIFF
--- a/src/lib/xml.ts
+++ b/src/lib/xml.ts
@@ -1,0 +1,44 @@
+// Minimal XML serializer — avoids adding a dependency for a few tags.
+type XmlAttrs = Record<string, string>;
+type XmlNode = string | undefined | XmlObj;
+type XmlObj = {
+  _attrs?: XmlAttrs;
+  [tag: string]: XmlNode | XmlAttrs | undefined;
+};
+
+function escapeXml(str: string) {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+function renderAttrs(attrs: XmlAttrs): string {
+  return Object.entries(attrs)
+    .map(([k, v]) => ` ${k}="${escapeXml(v)}"`)
+    .join("");
+}
+
+function renderTag(tag: string, child: XmlNode): string {
+  if (child === undefined) return "";
+  if (typeof child === "string") return `<${tag}>${escapeXml(child)}</${tag}>`;
+
+  const { _attrs, ...children } = child as XmlObj;
+  const attrsStr = _attrs ? renderAttrs(_attrs) : "";
+  const childKeys = Object.keys(children);
+
+  if (childKeys.length === 0) return `<${tag}${attrsStr}/>`;
+
+  const content = childKeys
+    .map((k) => renderTag(k, children[k] as XmlNode))
+    .join("");
+  return `<${tag}${attrsStr}>${content}</${tag}>`;
+}
+
+export function toXml(obj: { [tag: string]: XmlNode }): string {
+  return Object.entries(obj)
+    .map(([tag, child]) => renderTag(tag, child))
+    .join("");
+}

--- a/src/pages/events/rss.xml.ts
+++ b/src/pages/events/rss.xml.ts
@@ -1,4 +1,5 @@
 import { getEventDisplayType, getEventsCollection } from "@/lib/events";
+import { toXml } from "@/lib/xml";
 import rss from "@astrojs/rss";
 import type { APIRoute } from "astro";
 
@@ -10,11 +11,12 @@ export const GET: APIRoute = async function get(context) {
       "All the Fork it! events, from meetups to full day events, come take a look at what is happening near you!",
     site: context.site! + "/events",
     trailingSlash: false,
+    xmlns: {
+      atom: "http://www.w3.org/2005/Atom",
+      forkit: "https://forkit.community/rss",
+    },
     items: events.map((event) => {
       const location = event.data.location;
-      const venueCustomData = location
-        ? `<venue>${[location.name, location.address].filter(Boolean).join(" - ")}</venue>`
-        : "";
 
       return {
         title: `${event.data._computed.name}, ${getEventDisplayType(event.data.type)}`,
@@ -22,9 +24,25 @@ export const GET: APIRoute = async function get(context) {
         link: `${context.site}events/${event.id}`,
         pubDate: event.data.date,
         categories: [event.data.type],
-        customData: venueCustomData,
+        customData: location
+          ? toXml({
+              "forkit:venue": {
+                ...(location.name && { "forkit:name": location.name }),
+                "forkit:address": location.address,
+              },
+            })
+          : "",
       };
     }),
-    customData: `<language>en-EN</language>`,
+    customData: toXml({
+      language: "en-EN",
+      "atom:link": {
+        _attrs: {
+          href: `${context.site}events/rss.xml`,
+          rel: "self",
+          type: "application/rss+xml",
+        },
+      },
+    }),
   });
 };

--- a/src/pages/news/rss.xml.ts
+++ b/src/pages/news/rss.xml.ts
@@ -1,4 +1,5 @@
 import { getNewsCollection } from "@/lib/news";
+import { toXml } from "@/lib/xml";
 import rss from "@astrojs/rss";
 import type { APIRoute } from "astro";
 
@@ -10,6 +11,7 @@ export const GET: APIRoute = async function get(context) {
       "All the news about Fork it! Community. Conferences feedback, real life experience, we share it all.",
     site: context.site! + "/news",
     trailingSlash: false,
+    xmlns: { atom: "http://www.w3.org/2005/Atom" },
     items: news.map((article) => ({
       title: article.data.title,
       description: article.data.excerpt,
@@ -17,6 +19,15 @@ export const GET: APIRoute = async function get(context) {
       pubDate: article.data.date,
       categories: article.data.tags,
     })),
-    customData: `<language>en-EN</language>`,
+    customData: toXml({
+      language: "en-EN",
+      "atom:link": {
+        _attrs: {
+          href: `${context.site}news/rss.xml`,
+          rel: "self",
+          type: "application/rss+xml",
+        },
+      },
+    }),
   });
 };

--- a/src/pages/podcasts/rss.xml.ts
+++ b/src/pages/podcasts/rss.xml.ts
@@ -1,4 +1,5 @@
 import { getPodcastsEpisodesCollection } from "@/lib/podcasts";
+import { toXml } from "@/lib/xml";
 import rss from "@astrojs/rss";
 import type { APIRoute } from "astro";
 
@@ -9,6 +10,7 @@ export const GET: APIRoute = async function get(context) {
     description: "Listen to the Fork it! Community",
     site: context.site! + "/podcasts",
     trailingSlash: false,
+    xmlns: { atom: "http://www.w3.org/2005/Atom" },
     items: podcasts.map((podcast) => ({
       title: podcast.data.title,
       description: podcast.data.description,
@@ -16,5 +18,15 @@ export const GET: APIRoute = async function get(context) {
       pubDate: podcast.data.releaseDate,
       categories: podcast.data.tags,
     })),
+    customData: toXml({
+      language: "en-EN",
+      "atom:link": {
+        _attrs: {
+          href: `${context.site}podcasts/rss.xml`,
+          rel: "self",
+          type: "application/rss+xml",
+        },
+      },
+    }),
   });
 };


### PR DESCRIPTION
## Summary

- Add `atom:link` with `rel="self"` to all RSS feeds (events, news, podcasts) to pass validators
- Add missing `<language>` tag to podcasts feed
- Add `<forkit:venue>` custom element to events feed with proper XML namespace (`xmlns:forkit="https://forkit.community/rss"`)
- Extract a minimal `toXml` helper to `@/lib/xml.ts` to avoid raw XML string concatenation

## Test plan

- [ ] Validate `/events/rss.xml`, `/news/rss.xml`, `/podcasts/rss.xml` against an RSS 2.0 validator (e.g. validator.w3.org/feed/)
- [ ] Check events with a location include a `<forkit:venue>` tag with `<forkit:name>` and `<forkit:address>` sub-elements
- [ ] Check events without a location have no `<forkit:venue>` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced RSS feeds with Atom namespace metadata
  * Added self-referential links to all RSS feeds for improved feed reader compatibility
  * Events RSS feed now includes venue information (name and address) when available

<!-- end of auto-generated comment: release notes by coderabbit.ai -->