### PR TITLE
fix: replace deprecated z.string().url() with z.url()

### DIFF
--- a/src/schemas/channel.ts
+++ b/src/schemas/channel.ts
@@ -8,6 +8,6 @@ export const zChannel = () =>
     type: z.enum(CHANNEL_TYPES),
     link: z.object({
       title: z.string(),
-      href: z.string().url(),
+      href: z.url(),
     }),
   });

--- a/src/schemas/events.ts
+++ b/src/schemas/events.ts
@@ -45,7 +45,7 @@ export const zEventBasicInfo = ({ image }: SchemaContext) =>
       .object({
         afterMovie: z
           .object({
-            href: z.string().url(),
+            href: z.url(),
             thumbnail: z.object({
               image: image(),
               alt: z.string(),
@@ -54,11 +54,11 @@ export const zEventBasicInfo = ({ image }: SchemaContext) =>
           .optional(),
         vods: z
           .object({
-            href: z.string().url().describe("The playlist of the VODs"),
+            href: z.url().describe("The playlist of the VODs"),
           })
           .optional(),
         photos: z.object({
-          href: z.string().url().optional(),
+          href: z.url().optional(),
           sources: z
             .array(
               z
@@ -77,152 +77,151 @@ export const zEventBasicInfo = ({ image }: SchemaContext) =>
   });
 
 const zEventBase = ({ image }: SchemaContext) =>
-  zEventBasicInfo({ image }).merge(
-    z.object({
-      postponed: z
-        .object({
-          originalDate: z
-            .date()
-            .describe("The original date before it was postponed"),
-          message: z
-            .string()
-            .optional()
-            .describe(
-              "A default message will be displayed if the event's status is 'published-without-date'. Use this to override the default or to show a message if the event's status is 'published'",
-            ),
-        })
-        .optional()
-        .describe(
-          "Makes it possible to show that the event has been postponed. Use in combination with the 'status'.",
-        ),
+  z.object({
+    ...zEventBasicInfo({ image }).shape,
+    postponed: z
+      .object({
+        originalDate: z
+          .date()
+          .describe("The original date before it was postponed"),
+        message: z
+          .string()
+          .optional()
+          .describe(
+            "A default message will be displayed if the event's status is 'published-without-date'. Use this to override the default or to show a message if the event's status is 'published'",
+          ),
+      })
+      .optional()
+      .describe(
+        "Makes it possible to show that the event has been postponed. Use in combination with the 'status'.",
+      ),
 
-      cfp: z
-        .object({
-          href: z.string().url(),
-          endDate: z.date().optional(),
-        })
-        .optional(),
-      tickets: z
-        .object({
-          link: z.union([
-            z.string().url(),
-            z.array(
-              z.object({
-                title: z.string(),
-                description: z.string().optional(),
-                href: z.string().url().optional(),
-              }),
-            ),
-          ]),
-          endDate: z.date().optional(),
-          offers: z
-            .array(
-              z.object({
-                name: z.string(),
-                price: z.number().nonnegative(),
-                priceCurrency: z.string(),
-                availability: z.enum([
-                  "BackOrder",
-                  "Discontinued",
-                  "InStock",
-                  "InStoreOnly",
-                  "LimitedAvailability",
-                  "OnlineOnly",
-                  "OutOfStock",
-                  "PreOrder",
-                  "PreSale",
-                  "SoldOut",
-                ]),
-                validFrom: z.date(),
-              }),
-            )
-            .optional(),
-        })
-        .optional(),
-      prospectus: z
-        .object({
-          href: z.string().url(),
-          endDate: z.date().optional(),
-          title: z.string().optional(),
-        })
-        .optional(),
-      sponsors: z
-        .array(
-          z.object({
-            slug: reference("partners"), // <- the slug of the sponsor
-            level: z.string(), // <- the level of sponsoring
-            options: z.array(z.enum(["lunch"])).optional(), // <- if the sponsor has an option
-          }),
-        )
-        .optional(),
-      eventStatus: z.enum([
-        "EventCancelled",
-        "EventMovedOnline",
-        "EventPostponed",
-        "EventRescheduled",
-        "EventScheduled",
-      ]),
-      attendanceMode: z.enum([
-        "OfflineEventAttendanceMode",
-        "OnlineEventAttendanceMode",
-        "MixedEventAttendanceMode",
-      ]),
-      schedule: z
-        .object({
-          status: z.enum(["final", "not-final", "preview"]).default("final"),
-          stats: z
-            .array(z.object({ count: z.string(), name: z.string() }))
-            .length(4)
-            .optional(),
-          items: z
-            .array(
-              z.object({
-                // TODO Discriminated union
-                type: z.enum(["conference", "roundtable", "info", "lunch"]),
-                sponsors: z.array(reference("partners")).optional(),
-                description: z.string().optional(),
-                name: z.string().optional(),
-                slug: reference("talks").optional(),
-                startTime: z.date().optional(),
-                duration: z.number().optional().describe("Number of minutes"),
-                location: z.string().optional(),
-                locationUrl: z.string().url().optional(),
-                status: z
-                  .enum(["cancelled", "replacement", "published"])
-                  .default("published"),
-              }),
-            )
-            .optional(),
-        })
-        .optional(),
-      feedback: z
-        .object({
-          link: z.string().url(),
-        })
-        .optional(),
-      subPages: z.array(reference("eventsSubPages")).optional(),
-      sponsoringLevels: z.array(z.string()).optional(),
-      marketing: z
-        .object({
-          withFlags: z.boolean().optional().default(false),
-          videos: z
-            .array(
-              z.object({
-                title: z.string(),
-                href: z.string().url(),
-                thumbnail: z
-                  .object({
-                    image: image(),
-                    alt: z.string(),
-                  })
-                  .optional(),
-              }),
-            )
-            .optional(),
-        })
-        .optional(),
-    }),
-  );
+    cfp: z
+      .object({
+        href: z.url(),
+        endDate: z.date().optional(),
+      })
+      .optional(),
+    tickets: z
+      .object({
+        link: z.union([
+          z.url(),
+          z.array(
+            z.object({
+              title: z.string(),
+              description: z.string().optional(),
+              href: z.url().optional(),
+            }),
+          ),
+        ]),
+        endDate: z.date().optional(),
+        offers: z
+          .array(
+            z.object({
+              name: z.string(),
+              price: z.number().nonnegative(),
+              priceCurrency: z.string(),
+              availability: z.enum([
+                "BackOrder",
+                "Discontinued",
+                "InStock",
+                "InStoreOnly",
+                "LimitedAvailability",
+                "OnlineOnly",
+                "OutOfStock",
+                "PreOrder",
+                "PreSale",
+                "SoldOut",
+              ]),
+              validFrom: z.date(),
+            }),
+          )
+          .optional(),
+      })
+      .optional(),
+    prospectus: z
+      .object({
+        href: z.url(),
+        endDate: z.date().optional(),
+        title: z.string().optional(),
+      })
+      .optional(),
+    sponsors: z
+      .array(
+        z.object({
+          slug: reference("partners"), // <- the slug of the sponsor
+          level: z.string(), // <- the level of sponsoring
+          options: z.array(z.enum(["lunch"])).optional(), // <- if the sponsor has an option
+        }),
+      )
+      .optional(),
+    eventStatus: z.enum([
+      "EventCancelled",
+      "EventMovedOnline",
+      "EventPostponed",
+      "EventRescheduled",
+      "EventScheduled",
+    ]),
+    attendanceMode: z.enum([
+      "OfflineEventAttendanceMode",
+      "OnlineEventAttendanceMode",
+      "MixedEventAttendanceMode",
+    ]),
+    schedule: z
+      .object({
+        status: z.enum(["final", "not-final", "preview"]).default("final"),
+        stats: z
+          .array(z.object({ count: z.string(), name: z.string() }))
+          .length(4)
+          .optional(),
+        items: z
+          .array(
+            z.object({
+              // TODO Discriminated union
+              type: z.enum(["conference", "roundtable", "info", "lunch"]),
+              sponsors: z.array(reference("partners")).optional(),
+              description: z.string().optional(),
+              name: z.string().optional(),
+              slug: reference("talks").optional(),
+              startTime: z.date().optional(),
+              duration: z.number().optional().describe("Number of minutes"),
+              location: z.string().optional(),
+              locationUrl: z.url().optional(),
+              status: z
+                .enum(["cancelled", "replacement", "published"])
+                .default("published"),
+            }),
+          )
+          .optional(),
+      })
+      .optional(),
+    feedback: z
+      .object({
+        link: z.url(),
+      })
+      .optional(),
+    subPages: z.array(reference("eventsSubPages")).optional(),
+    sponsoringLevels: z.array(z.string()).optional(),
+    marketing: z
+      .object({
+        withFlags: z.boolean().optional().default(false),
+        videos: z
+          .array(
+            z.object({
+              title: z.string(),
+              href: z.url(),
+              thumbnail: z
+                .object({
+                  image: image(),
+                  alt: z.string(),
+                })
+                .optional(),
+            }),
+          )
+          .optional(),
+      })
+      .optional(),
+  });
 
 const zMeetup = () => z.object({ type: z.literal("meetup") });
 const zEventClassic = () =>
@@ -233,6 +232,6 @@ const zEventClassic = () =>
 export type Event = z.infer<ReturnType<typeof zEvent>>;
 export const zEvent = ({ image }: SchemaContext) =>
   z.discriminatedUnion("type", [
-    zEventBase({ image }).merge(zMeetup()),
-    zEventBase({ image }).merge(zEventClassic()),
+    zEventBase({ image }).extend(zMeetup().shape),
+    zEventBase({ image }).extend(zEventClassic().shape),
   ]);

--- a/src/schemas/forKidsEvent.ts
+++ b/src/schemas/forKidsEvent.ts
@@ -4,27 +4,27 @@ import { zAgeRange } from "./utils";
 import { zEventBasicInfo } from "./events";
 
 export const zForKidsEvent = ({ image }: SchemaContext) =>
-  zEventBasicInfo({ image }).merge(
-    z.object({
-      startTime: z.date(),
-      endTime: z.date().optional(),
-      workshops: z.array(reference("forKidsWorkshop")).optional(),
-      ageRange: zAgeRange(),
-      tickets: z
-        .object({
-          link: z.string().url(),
-          endDate: z.date().optional(),
-        })
-        .optional(),
-      organizers: z
-        .array(
-          z.object({
-            person: reference("people"),
-            role: z.string().optional(),
-          }),
-        )
-        .optional()
-        .describe("Collection of people that organize the event"),
-    }),
-  );
+  z.object({
+    ...zEventBasicInfo({ image }).shape,
+    startTime: z.date(),
+    endTime: z.date().optional(),
+    workshops: z.array(reference("forKidsWorkshop")).optional(),
+    ageRange: zAgeRange(),
+    tickets: z
+      .object({
+        link: z.url(),
+        endDate: z.date().optional(),
+      })
+      .optional(),
+    organizers: z
+      .array(
+        z.object({
+          person: reference("people"),
+          role: z.string().optional(),
+        }),
+      )
+      .optional()
+      .describe("Collection of people that organize the event"),
+  });
+
 export type ForKidsEvent = z.infer<ReturnType<typeof zForKidsEvent>>;

--- a/src/schemas/partners.ts
+++ b/src/schemas/partners.ts
@@ -6,7 +6,7 @@ export type Partner = z.infer<ReturnType<typeof zPartner>>;
 export const zPartner = ({ image }: SchemaContext) =>
   z.object({
     name: z.string(),
-    href: z.string().url(),
+    href: z.url(),
     logos: z.object({
       bgWhite: image(),
       noBg: image(),
@@ -16,7 +16,7 @@ export const zPartner = ({ image }: SchemaContext) =>
       .array(
         z.object({
           type: zSocialTypes,
-          href: z.string().url(),
+          href: z.url(),
         }),
       )
       .optional(),

--- a/src/schemas/people.ts
+++ b/src/schemas/people.ts
@@ -12,14 +12,14 @@ export const zPerson = ({ image }: SchemaContext) =>
       .array(
         z.object({
           type: zSocialTypes,
-          href: z.string().url(),
+          href: z.url(),
         }),
       )
       .optional(),
     company: z
       .object({
         title: z.string(),
-        href: z.string().url().optional(),
+        href: z.url().optional(),
       })
       .optional(),
     forkit: z

--- a/src/schemas/podcasts.ts
+++ b/src/schemas/podcasts.ts
@@ -18,14 +18,14 @@ export const zPodcast = ({ image }: SchemaContext) =>
     title: z.string(),
     subtitle: z.string().optional(),
     cover: image(),
-    rssFeed: z.string().url().optional(),
+    rssFeed: z.url().optional(),
     language: zLanguage(),
     keywords: z.array(z.string()).optional(),
     urls: z
       .array(
         z.object({
           platform: zPlatform(),
-          url: z.string().url(),
+          url: z.url(),
         }),
       )
       .optional(),
@@ -41,7 +41,7 @@ export const zEpisode = ({ image }: SchemaContext) =>
       .array(
         z.object({
           platform: zPlatform(),
-          url: z.string().url(),
+          url: z.url(),
         }),
       )
       .optional(),

--- a/src/schemas/talks.ts
+++ b/src/schemas/talks.ts
@@ -12,7 +12,7 @@ export const zTalk = () =>
     language: zLanguage(),
     feedback: z
       .object({
-        link: z.string().url(),
+        link: z.url(),
       })
       .optional(),
     hosts: z


### PR DESCRIPTION
Updated all Zod schemas to use the non-deprecated z.url() method instead of z.string().url(). Also refactored events.ts and forKidsEvent.ts to use .shape spread syntax and .extend() instead of .merge() to match Zod's current recommended patterns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Standardized URL validation patterns across multiple data schemas for improved consistency and maintainability throughout the codebase.
  * Refactored internal schema construction to enhance code clarity and reliability.
  * All public-facing APIs remain unchanged and fully backward compatible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->