### PR TITLE
fix: use x.com instead of twitter.com to avoid redirection

### DIFF
--- a/src/components/ShareButton/index.tsx
+++ b/src/components/ShareButton/index.tsx
@@ -183,7 +183,7 @@ function getTwitterShareUrl(params: {
   const encodedMessage = encodeURIComponent(
     params.message?.replace("Fork it!", "@ForkitCommunity") ?? "",
   );
-  return `https://twitter.com/intent/tweet?url=${encodedUrl}&text=${encodedMessage}`;
+  return `https://x.com/intent/tweet?url=${encodedUrl}&text=${encodedMessage}`;
 }
 
 function getBlueskyShareUrl(params: {

--- a/src/content/partners/attineos/index.mdx
+++ b/src/content/partners/attineos/index.mdx
@@ -9,7 +9,7 @@ socials:
   - type: "linkedin"
     href: https://www.linkedin.com/company/attineos/
   - type: "x"
-    href: https://twitter.com/Attineos
+    href: https://x.com/Attineos
   - type: "instagram"
     href: https://www.instagram.com/attineos_officiel/
 ---

--- a/src/content/partners/bearstudio/index.mdx
+++ b/src/content/partners/bearstudio/index.mdx
@@ -9,7 +9,7 @@ socials:
   - type: "linkedin"
     href: https://www.linkedin.com/company/bearstudio/
   - type: "x"
-    href: https://twitter.com/_BearStudio
+    href: https://x.com/_BearStudio
 ---
 
 BearStudio is a french den full of digital experts.

--- a/src/content/partners/magnolia/index.mdx
+++ b/src/content/partners/magnolia/index.mdx
@@ -9,7 +9,7 @@ socials:
   - type: "linkedin"
     href: https://www.linkedin.com/company/groupe-magnolia
   - type: "x"
-    href: https://twitter.com/magnolia_groupe
+    href: https://x.com/magnolia_groupe
   - type: "instagram"
     href: https://www.instagram.com/insta.magnolia.fr/
 ---

--- a/src/content/people/andrey-sitnik/index.mdx
+++ b/src/content/people/andrey-sitnik/index.mdx
@@ -7,7 +7,7 @@ company:
   href: https://evilmartians.com/
 socials:
   - type: "x"
-    href: https://twitter.com/sitnikcode
+    href: https://x.com/sitnikcode
   - type: "github"
     href: https://github.com/ai
 ---

--- a/src/content/people/ayoub-alouane/index.mdx
+++ b/src/content/people/ayoub-alouane/index.mdx
@@ -7,7 +7,7 @@ company:
   href: https://fr.adservio.fr/
 socials:
   - type: "x"
-    href: https://twitter.com/alouane_med
+    href: https://x.com/alouane_med
 ---
 
 I am Ayoub Alouane, 29 years old, working as a DevRel and TechLead in Adservio, Moroccan coming from Africa, starting a new journey in France,

--- a/src/content/people/clement-michel/index.mdx
+++ b/src/content/people/clement-michel/index.mdx
@@ -9,5 +9,5 @@ socials:
   - type: "linkedin"
     href: https://www.linkedin.com/in/clementmic/
   - type: "x"
-    href: https://twitter.com/clement_michel
+    href: https://x.com/clement_michel
 ---

--- a/src/content/people/francois-best/index.mdx
+++ b/src/content/people/francois-best/index.mdx
@@ -7,7 +7,7 @@ company:
   href: https://francoisbest.com/
 socials:
   - type: "x"
-    href: https://twitter.com/fortysevenfx
+    href: https://x.com/fortysevenfx
   - type: "github"
     href: "https://github.com/franky47"
   - type: "linkedin"

--- a/src/content/people/frederic-bisson/index.mdx
+++ b/src/content/people/frederic-bisson/index.mdx
@@ -4,7 +4,7 @@ avatar: ./frederic-bisson.jpg
 job: Web developer
 socials:
   - type: "x"
-    href: https://twitter.com/zigazou
+    href: https://x.com/zigazou
   - type: "github"
     href: https://github.com/zigazou
 ---

--- a/src/content/people/ivan-dalmet/index.mdx
+++ b/src/content/people/ivan-dalmet/index.mdx
@@ -11,7 +11,7 @@ socials:
   - type: 'linkedin'
     href: https://www.linkedin.com/in/ivandalmet/
   - type: 'x'
-    href: https://twitter.com/IvanDalmet
+    href: https://x.com/IvanDalmet
 forkit:
   avatar: ./fork-it-ivan-dalmet.jpg
   role: founder

--- a/src/content/people/magali-de-labareyre/index.mdx
+++ b/src/content/people/magali-de-labareyre/index.mdx
@@ -7,7 +7,7 @@ company:
   href: https://www.ovhcloud.com/fr/
 socials:
   - type: "x"
-    href: https://twitter.com/mag_ovh
+    href: https://x.com/mag_ovh
 ---
 
 La tech est un secteur qui m'a tout de suite passionnée et, bien que diplomée en 2020 en Ingénieurie RH, j'ai choisis de me spécialiser en rejoignant OVHcloud.

--- a/src/content/people/nhung-duong/index.mdx
+++ b/src/content/people/nhung-duong/index.mdx
@@ -9,7 +9,7 @@ socials:
   - type: 'linkedin'
     href: https://www.linkedin.com/in/n-duong/
   - type: 'x'
-    href: https://twitter.com/hnnhung_duong
+    href: https://x.com/hnnhung_duong
 forkit:
   role: founder
 ---

--- a/src/content/people/nicolas-torion/index.mdx
+++ b/src/content/people/nicolas-torion/index.mdx
@@ -9,5 +9,5 @@ socials:
   - type: 'linkedin'
     href: https://www.linkedin.com/in/nicolas-torion/
   - type: 'x'
-    href: https://twitter.com/NicoTotor
+    href: https://x.com/NicoTotor
 ---

--- a/src/content/people/olivier-huber/index.mdx
+++ b/src/content/people/olivier-huber/index.mdx
@@ -7,7 +7,7 @@ company:
   href: https://aiven.io/
 socials:
   - type: "x"
-    href: https://twitter.com/olivierhuber
+    href: https://x.com/olivierhuber
   - type: "github"
     href: https://github.com/olivierhuber
 ---

--- a/src/content/people/quentin-lerebours/index.mdx
+++ b/src/content/people/quentin-lerebours/index.mdx
@@ -7,7 +7,7 @@ company:
   href: https://www.bearstudio.fr/
 socials:
   - type: "x"
-    href: https://twitter.com/qlerebours_
+    href: https://x.com/qlerebours_
   - type: "linkedin"
     href: https://www.linkedin.com/in/quentin-lerebours/
 ---

--- a/src/content/people/rudy-baer/index.mdx
+++ b/src/content/people/rudy-baer/index.mdx
@@ -9,7 +9,7 @@ socials:
   - type: 'linkedin'
     href: https://www.linkedin.com/in/rudybaer/
   - type: 'x'
-    href: https://twitter.com/RudyBaer
+    href: https://x.com/RudyBaer
 forkit:
   role: founder
 ---

--- a/src/content/people/xavier-van-de-woestyne/index.mdx
+++ b/src/content/people/xavier-van-de-woestyne/index.mdx
@@ -7,7 +7,7 @@ company:
   href: https://tarides.com/
 socials:
   - type: "x"
-    href: https://twitter.com/vdwxv
+    href: https://x.com/vdwxv
   - type: "github"
     href: https://github.com/xvw
 ---

--- a/src/content/people/yoann-fleury/index.mdx
+++ b/src/content/people/yoann-fleury/index.mdx
@@ -9,7 +9,7 @@ socials:
   - type: 'bluesky'
     href: https://bsky.app/profile/yoannfleury.dev
   - type: 'x'
-    href: 'https://twitter.com/YoannFleuryDev'
+    href: 'https://x.com/YoannFleuryDev'
   - type: 'linkedin'
     href: 'https://www.linkedin.com/in/yoannfleurydev/'
   - type: 'github'

--- a/src/content/socials.ts
+++ b/src/content/socials.ts
@@ -53,7 +53,7 @@ const SOCIALS: Array<{
   },
   {
     label: "X Twitter",
-    href: "https://twitter.com/ForkitCommunity",
+    href: "https://x.com/ForkitCommunity",
     icon: FaXTwitter,
     level: "secondary",
   },


### PR DESCRIPTION
I replaced `twitter.com` with `x.com` to avoid redirection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated all social media links and share functionality to use the X domain instead of Twitter domain across profiles, partner pages, and share buttons. This ensures accurate routing to current X/Twitter accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->