### PR TITLE
fix: prospectus link

### DIFF
--- a/src/content/events/2026-france-rouen/index.mdx
+++ b/src/content/events/2026-france-rouen/index.mdx
@@ -8,7 +8,7 @@ location:
   address: 107 All. François Mitterrand, 76100, Rouen
   image: "./le-village-by-ca.jpg"
 prospectus:
-  href: https://drive.google.com/file/d/1GYMPxV9rUJFu3gii9CmAcxqR9Cd_Eyz9/view?usp=sharing
+  href: https://drive.google.com/drive/folders/16JZ1qHliGan2tkGMACDABhiRbmWDfUfv
 cfp:
   href: https://conference-hall.io/fork-it-community-france-rouen-2026
   end: 2026-04-19T23:59:00.000Z


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the prospectus link for the 2026 France Rouen event.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->