### PR TITLE
feat: add missing meta descriptions for Hanoi 2026 and Tunis 2026

### DIFF
--- a/src/content/events/2026-tunisia-tunis/index.mdx
+++ b/src/content/events/2026-tunisia-tunis/index.mdx
@@ -21,6 +21,12 @@ tickets:
       href: https://luma.com/fork-it-full-day-event-tunis-2026
     - title: No Credit Card?
       description: Contact us by phone at +216 26 659 662 or +216 26 609 008
+excerpt: >
+  Real talks, real experiences, real connections. Fork it! returns to Tunis in
+  April 2026 at the Cité de la Culture for a full-day conference bringing
+  together 200 professionals and creatives. Enjoy a diverse lineup of
+  international and local speakers sharing practical insights and real-world
+  experiences in French, English, and Arabic.
 sponsoringLevels:
   - SILVER
   - BRONZE

--- a/src/content/events/2026-vietnam-hanoi/index.mdx
+++ b/src/content/events/2026-vietnam-hanoi/index.mdx
@@ -97,6 +97,12 @@ schedule:
       startTime: 2026-03-07T18:30:00.000Z
       location: Laca 24
       locationUrl: https://maps.google.com/?q=Laca+24,+24+Ly+Quoc+Su,+Hoan+Kiem,+Ha+Noi
+excerpt: >
+  After the success of our previous meetups in Hanoï, Fork it! is back for a
+  full-day conference in March 2026. Join developers, tech enthusiasts, and
+  curious minds for authentic talks, fresh perspectives, and real-world
+  experiences shared by local and international speakers shaping today's tech
+  scene.
 eventStatus: EventScheduled
 attendanceMode: OfflineEventAttendanceMode
 prospectus:


### PR DESCRIPTION
Add excerpt fields to improve SEO and provide better preview text for the events, matching the pattern used for Rouen 2026.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced event pages for Fork it! 2026 Tunis and Hanoi with expanded descriptions and event details, providing users with more comprehensive event information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->