### PR TITLE
FEAT : Add keynote badge on schedule item

### DIFF
--- a/src/components/Badge/index.astro
+++ b/src/components/Badge/index.astro
@@ -1,5 +1,0 @@
-<span
-  class="flex w-fit items-center gap-1.5 rounded-full border border-black/60 bg-black/40 px-2 py-0.5 text-2xs font-bold uppercase leading-none opacity-60 transition group-hover:opacity-100"
->
-  <slot />
-</span>

--- a/src/components/Conferences/ConferenceCard.astro
+++ b/src/components/Conferences/ConferenceCard.astro
@@ -5,7 +5,7 @@ import { lunalink } from "@bearstudio/lunalink";
 import { ROUTES } from "@/routes.gen";
 import { getEntries } from "astro:content";
 import SpeakerForCard from "../Schedule/SpeakerForCard.astro";
-import Badge from "@/components/Badge/index.astro";
+import { Badge } from "@/components/ui/badge";
 import { render } from "astro:content";
 import { LuSquarePlay } from "react-icons/lu";
 
@@ -83,7 +83,7 @@ const { Content } = await render(conference);
     </span>
     {
       conference.data.vod && conference.data.vod.youtubeId && (
-        <Badge>
+        <Badge variant="card">
           <LuSquarePlay className="text-base" />
           <span>VOD available</span>
         </Badge>

--- a/src/components/Schedule/CardConference.astro
+++ b/src/components/Schedule/CardConference.astro
@@ -2,7 +2,7 @@
 import { type CollectionEntry, getEntries, getEntry } from "astro:content";
 import { IoLanguageSharp, IoSparklesSharp } from "react-icons/io5";
 import SpeakerForCard from "./SpeakerForCard.astro";
-import Badge from "@/components/Badge/index.astro";
+import { Badge } from "@/components/ui/badge";
 import { lunalink } from "@bearstudio/lunalink";
 import { ROUTES } from "@/routes.gen";
 import { LuSquarePlay } from "react-icons/lu";
@@ -58,7 +58,7 @@ const scheduleItem = (event.data.schedule?.items ?? []).find(
         </p>
         <div class="flex items-center gap-2">
           {scheduleItem?.type === "keynote" && (
-            <Badge>{scheduleItem.type}</Badge>
+            <Badge variant="card">{scheduleItem.type}</Badge>
           )}
           {scheduleItem?.status === "cancelled" && (
             <div class="h-full w-fit rounded-full bg-white/10 px-2 py-1 text-white">
@@ -102,12 +102,12 @@ const scheduleItem = (event.data.schedule?.items ?? []).find(
           scheduleItem?.status === "cancelled" ? "grayscale" : "",
         )}
       >
-        <Badge>
+        <Badge variant="card">
           <IoLanguageSharp className="text-base" />
           <span>Talk in {talk.data.language}</span>
         </Badge>
         {talk.data.vod && talk.data.vod.youtubeId && (
-          <Badge>
+          <Badge variant="card">
             <LuSquarePlay className="text-base" />
             <span>VOD available</span>
           </Badge>

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,37 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils-client";
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
+        outline: "text-foreground",
+        card: "flex w-fit items-center gap-1.5 rounded-full border border-black/60 bg-black/40 px-2 py-0.5 text-2xs font-bold uppercase leading-none opacity-60 transition group-hover:opacity-100",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  );
+}
+
+export { Badge, badgeVariants };


### PR DESCRIPTION
close #643 

## Video

https://github.com/user-attachments/assets/451a4c6b-76e3-43d0-8dd7-abe75e404dbe



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Introduced a shared Badge UI component with multiple styling variants for consistent label and chip rendering across the application.
  * Updated conference cards to use the Badge component for VOD indicators and status badges, improving UI consistency.
  * Enhanced layout alignment and spacing in conference card headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->