### PR TITLE
fix: exclude actions from Vercel ISR to work around missing duplex option

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -19,11 +19,13 @@ const adapter =
   import.meta.env.DEV
     ? node({ mode: "standalone" })
     : vercel({
-        isr: true,
-        // TODO: Revert — exclude search action due to @astrojs/vercel ISR bug:
-        // POST body is reconstructed without `duplex: 'half'`, causing a TypeError.
-        // Remove this once the bug is fixed in Astro/Vercel adapter.
-        excludeFiles: ["./src/actions/search.ts"],
+        isr: {
+          // TODO: Revert — exclude actions from ISR due to @astrojs/vercel bug:
+          // ISR entrypoint reconstructs POST body without `duplex: 'half'`, causing a TypeError.
+          // Excluding actions from ISR lets them go directly to the serverless function.
+          // Remove this once the bug is fixed in Astro/Vercel adapter.
+          exclude: [/^\/_actions\/.*/],
+        },
       });
 
 // https://astro.build/config


### PR DESCRIPTION

<img width="1016" height="286" alt="image" src="https://github.com/user-attachments/assets/5235f9f1-70c2-470b-ba7b-4975cfd528c6" />

### The cmdk search was returning no results (events, people, etc.) in production on Vercel after the upgrades to the deps

Root cause: Astro Actions use POST requests. The @astrojs/vercel ISR entrypoint reconstructs the POST body without `duplex: 'half'`, causing a TypeError in the serverless function. The search fell back to indexing only menu items.

Fix: replaced the Astro action (`src/actions/search.ts`) with a prerendered GET endpoint (`src/pages/api/search.ts`). GET has no body, so the duplex issue never occurs. With `export const prerender = true` the file is built as a static JSON asset at build time and served directly from Vercel's CDN edge — zero serverless invocations, no ISR dependency.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved production deployment reliability by excluding backend action endpoints from incremental static regeneration, preventing unnecessary content reprocessing and ensuring more stable, performant updates to live content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->