### PR TITLE
fix: use valid BCP 47 language code in RSS feeds

### DIFF
--- a/src/pages/events/rss.xml.ts
+++ b/src/pages/events/rss.xml.ts
@@ -35,7 +35,7 @@ export const GET: APIRoute = async function get(context) {
       };
     }),
     customData: toXml({
-      language: "en-EN",
+      language: "en",
       "atom:link": {
         _attrs: {
           href: `${context.site}events/rss.xml`,

--- a/src/pages/news/rss.xml.ts
+++ b/src/pages/news/rss.xml.ts
@@ -20,7 +20,7 @@ export const GET: APIRoute = async function get(context) {
       categories: article.data.tags,
     })),
     customData: toXml({
-      language: "en-EN",
+      language: "en",
       "atom:link": {
         _attrs: {
           href: `${context.site}news/rss.xml`,

--- a/src/pages/podcasts/rss.xml.ts
+++ b/src/pages/podcasts/rss.xml.ts
@@ -19,7 +19,7 @@ export const GET: APIRoute = async function get(context) {
       categories: podcast.data.tags,
     })),
     customData: toXml({
-      language: "en-EN",
+      language: "en",
       "atom:link": {
         _attrs: {
           href: `${context.site}podcasts/rss.xml`,


### PR DESCRIPTION
Closes #671

Replace non-standard `en-EN` with `en` in all three RSS feeds (events, news, podcasts).

We could use en-US based on our current content, but en is broader and will give us more flexibility in the future.

RSS Events: https://validator.w3.org/feed/check.cgi?url=https%3A%2F%2Fforkit-community-git-ntatoud-fix-bcp47-rss-lang-bearstudio.vercel.app%2Fevents%2Frss.xml

RSS Podcasts: https://validator.w3.org/feed/check.cgi?url=https%3A%2F%2Fforkit-community-git-ntatoud-fix-bcp47-rss-lang-bearstudio.vercel.app%2Fpodcasts%2Frss.xml

RSS News: https://validator.w3.org/feed/check.cgi?url=https%3A%2F%2Fforkit-community-git-ntatoud-fix-bcp47-rss-lang-bearstudio.vercel.app%2Fnews%2Frss.xml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected RSS feed language metadata format across events, news, and podcasts sections. The language code now follows standard format, ensuring better compatibility with RSS readers and feed aggregators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->