### PR TITLE
feat: display Luma event ratings and comments

### DIFF
--- a/src/components/EventComment/index.astro
+++ b/src/components/EventComment/index.astro
@@ -1,0 +1,23 @@
+---
+import StarRating from "@/components/StarRating/index.astro";
+
+interface Props {
+  comment: {
+    author: string;
+    text: string;
+    score: number;
+  };
+}
+
+const { comment } = Astro.props;
+---
+
+<div
+  class="flex w-72 flex-none flex-col gap-3 rounded-lg bg-white/5 p-6 backdrop-blur-md"
+>
+  <StarRating score={comment.score} size="sm" />
+  <p class="flex-1 text-sm italic leading-relaxed opacity-80">
+    &ldquo;{comment.text}&rdquo;
+  </p>
+  <p class="text-xs font-medium opacity-60">&mdash; {comment.author}</p>
+</div>

--- a/src/components/EventRating/index.astro
+++ b/src/components/EventRating/index.astro
@@ -14,5 +14,7 @@ const { averageScore, count, class: className } = Astro.props;
 <div class={cn("flex items-center gap-2", className)}>
   <StarRating score={averageScore} />
   <span class="text-sm font-medium">{averageScore.toFixed(1)}/5</span>
-  <span class="text-sm opacity-60">based on {count} ratings</span>
+  <span class="text-sm opacity-60"
+    >based on {count} {count === 1 ? "rating" : "ratings"}</span
+  >
 </div>

--- a/src/components/EventRating/index.astro
+++ b/src/components/EventRating/index.astro
@@ -3,16 +3,16 @@ import { cn } from "@/lib/utils-client";
 import StarRating from "@/components/StarRating/index.astro";
 
 interface Props {
-  score: number;
+  averageScore: number;
   count: number;
   class?: string;
 }
 
-const { score, count, class: className } = Astro.props;
+const { averageScore, count, class: className } = Astro.props;
 ---
 
 <div class={cn("flex items-center gap-2", className)}>
-  <StarRating score={score} />
-  <span class="text-sm font-medium">{score.toFixed(1)}/5</span>
+  <StarRating score={averageScore} />
+  <span class="text-sm font-medium">{averageScore.toFixed(1)}/5</span>
   <span class="text-sm opacity-60">based on {count} ratings</span>
 </div>

--- a/src/components/EventRating/index.astro
+++ b/src/components/EventRating/index.astro
@@ -1,0 +1,18 @@
+---
+import { cn } from "@/lib/utils-client";
+import StarRating from "@/components/StarRating/index.astro";
+
+interface Props {
+  score: number;
+  count: number;
+  class?: string;
+}
+
+const { score, count, class: className } = Astro.props;
+---
+
+<div class={cn("flex items-center gap-2", className)}>
+  <StarRating score={score} />
+  <span class="text-sm font-medium">{score.toFixed(1)}/5</span>
+  <span class="text-sm opacity-60">based on {count} ratings</span>
+</div>

--- a/src/components/StarRating/index.astro
+++ b/src/components/StarRating/index.astro
@@ -1,0 +1,34 @@
+---
+import { cn } from "@/lib/utils-client";
+import { MdStar, MdStarHalf, MdStarOutline } from "react-icons/md";
+
+interface Props {
+  score: number;
+  size?: "sm" | "md";
+  class?: string;
+}
+
+const { score, size = "md", class: className } = Astro.props;
+
+const fullStars = Math.floor(score);
+const hasHalf = score - fullStars >= 0.25 && score - fullStars < 0.75;
+const roundedUp = score - fullStars >= 0.75;
+const filledStars = fullStars + (roundedUp ? 1 : 0);
+const emptyStars = 5 - filledStars - (hasHalf ? 1 : 0);
+
+const iconSize = size === "sm" ? "size-4" : "size-5";
+---
+
+<div class={cn("flex text-primary", className)}>
+  {
+    Array.from({ length: filledStars }).map(() => (
+      <MdStar className={iconSize} />
+    ))
+  }
+  {hasHalf && <MdStarHalf className={iconSize} />}
+  {
+    Array.from({ length: emptyStars }).map(() => (
+      <MdStarOutline className={iconSize} />
+    ))
+  }
+</div>

--- a/src/components/StarRating/index.astro
+++ b/src/components/StarRating/index.astro
@@ -19,7 +19,11 @@ const emptyStars = 5 - filledStars - (hasHalf ? 1 : 0);
 const iconSize = size === "sm" ? "size-4" : "size-5";
 ---
 
-<div class={cn("flex text-primary", className)}>
+<div
+  role="img"
+  aria-label={`${score} out of 5 stars`}
+  class={cn("flex text-primary", className)}
+>
   {
     Array.from({ length: filledStars }).map(() => (
       <MdStar className={iconSize} />

--- a/src/content/events/2025-malaysia-kuala-lumpur/index.mdx
+++ b/src/content/events/2025-malaysia-kuala-lumpur/index.mdx
@@ -179,7 +179,7 @@ afterEventContent:
       - image: images/image4.jpg
         alt: Attendees looking at a talk
   rating:
-    score: 4
+    averageScore: 4
     count: 36
 ---
 

--- a/src/content/events/2025-malaysia-kuala-lumpur/index.mdx
+++ b/src/content/events/2025-malaysia-kuala-lumpur/index.mdx
@@ -178,6 +178,9 @@ afterEventContent:
         alt: Nicolas Torion speaking at Fork it! Kuala Lumpur
       - image: images/image4.jpg
         alt: Attendees looking at a talk
+  rating:
+    score: 4
+    count: 36
 ---
 
 import { buttonVariants } from '@/components/ui/button'

--- a/src/content/events/2025-tunisia-tunis/index.mdx
+++ b/src/content/events/2025-tunisia-tunis/index.mdx
@@ -178,7 +178,7 @@ afterEventContent:
       - image: images/souhir-and-jihene-talking-together.jpg
         alt: Souhir Mkaouar and Jihène Mejri talking together
   rating:
-    score: 4.9
+    averageScore: 4.9
     count: 15
 ---
 

--- a/src/content/events/2025-tunisia-tunis/index.mdx
+++ b/src/content/events/2025-tunisia-tunis/index.mdx
@@ -177,6 +177,9 @@ afterEventContent:
         alt: Matthieu Coulon speaking at Fork it! Tunis
       - image: images/souhir-and-jihene-talking-together.jpg
         alt: Souhir Mkaouar and Jihène Mejri talking together
+  rating:
+    score: 4.9
+    count: 15
 ---
 
 import { buttonVariants } from '@/components/ui/button'

--- a/src/content/events/2026-vietnam-hanoi/index.mdx
+++ b/src/content/events/2026-vietnam-hanoi/index.mdx
@@ -178,7 +178,7 @@ afterEventContent:
       - image: images/group-photo.jpeg
         alt: Speakers and attendees gathered for a group photo
   rating:
-    score: 4.8
+    averageScore: 4.8
     count: 25
     comments:
       - author: "Khoi Bui-Kinh"

--- a/src/content/events/2026-vietnam-hanoi/index.mdx
+++ b/src/content/events/2026-vietnam-hanoi/index.mdx
@@ -181,10 +181,10 @@ afterEventContent:
     averageScore: 4.8
     count: 25
     comments:
-      - author: "Khoi Bui-Kinh"
+      - author: "Khoi B."
         score: 5
         text: "Need more of event dedicated to tech folks like this in Vietnam. When's the next one?"
-      - author: "Dieu Dang Quoc"
+      - author: "Dieu D."
         score: 5
         text: "This has been a very interesting experience and I've learned a lot of new things."
       - author: "Prince"
@@ -193,7 +193,7 @@ afterEventContent:
       - author: "ChloeTran"
         score: 5
         text: "I really enjoyed the ForkIt event last weekend. Everything was organized very professionally, and the sessions brought many valuable insights from the speakers. It was great to hear different perspectives and connect with the tech community. Looking forward to the next ForkIt event in Vietnam!!"
-      - author: "Steve Nguyen"
+      - author: "Steve N."
         score: 5
         text: "Super insightful; amazed with the hosts of this event. Really helpful for anyone wanted to learn more on AI or work with AI in 2026."
       - author: "Ellie"
@@ -202,13 +202,13 @@ afterEventContent:
       - author: "Hapuya"
         score: 5
         text: "I was especially impressed by how smoothly everything was coordinated - from the agenda to the networking sessions - which made it easy for participants to engage and connect. The event not only provided valuable knowledge and fresh perspectives but also created a great space for meaningful discussions within the community."
-      - author: "Phan Khánh Linh"
+      - author: "Phan K."
         score: 5
         text: "I joined Forkit in Hanoi on Mar 7 and really enjoyed the event. The speakers shared a lot of interesting perspectives and practical experiences. The organization was also very smooth, and everything ran right on timeline."
-      - author: "Nghia Tran"
+      - author: "Nghia T."
         score: 5
         text: "It was my first time participating in a conferences. I had a very great time there. I am looking forward to next year conferences."
-      - author: "Nguyen Nhu Thanh"
+      - author: "Nguyen N."
         score: 5
         text: "The event was amazing. I really enjoyed most of the sessions from the speakers who participated today, especially Michel Boretti's session on web redesign. He truly has great taste."
 subPages:

--- a/src/content/events/2026-vietnam-hanoi/index.mdx
+++ b/src/content/events/2026-vietnam-hanoi/index.mdx
@@ -177,6 +177,40 @@ afterEventContent:
         alt: Full room view of attendees watching a talk
       - image: images/group-photo.jpeg
         alt: Speakers and attendees gathered for a group photo
+  rating:
+    score: 4.8
+    count: 25
+    comments:
+      - author: "Khoi Bui-Kinh"
+        score: 5
+        text: "Need more of event dedicated to tech folks like this in Vietnam. When's the next one?"
+      - author: "Dieu Dang Quoc"
+        score: 5
+        text: "This has been a very interesting experience and I've learned a lot of new things."
+      - author: "Prince"
+        score: 5
+        text: "The event was worthwhile, and I'm glad I could make it. I hope to see more of these kinds of events in Hanoi."
+      - author: "ChloeTran"
+        score: 5
+        text: "I really enjoyed the ForkIt event last weekend. Everything was organized very professionally, and the sessions brought many valuable insights from the speakers. It was great to hear different perspectives and connect with the tech community. Looking forward to the next ForkIt event in Vietnam!!"
+      - author: "Steve Nguyen"
+        score: 5
+        text: "Super insightful; amazed with the hosts of this event. Really helpful for anyone wanted to learn more on AI or work with AI in 2026."
+      - author: "Ellie"
+        score: 5
+        text: "Really enjoyed the event. Everything was well organized and the sessions were both insightful and practical. The speakers shared great perspectives, and it was inspiring to see the tech community come together like this. Looking forward to future editions."
+      - author: "Hapuya"
+        score: 5
+        text: "I was especially impressed by how smoothly everything was coordinated - from the agenda to the networking sessions - which made it easy for participants to engage and connect. The event not only provided valuable knowledge and fresh perspectives but also created a great space for meaningful discussions within the community."
+      - author: "Phan Khánh Linh"
+        score: 5
+        text: "I joined Forkit in Hanoi on Mar 7 and really enjoyed the event. The speakers shared a lot of interesting perspectives and practical experiences. The organization was also very smooth, and everything ran right on timeline."
+      - author: "Nghia Tran"
+        score: 5
+        text: "It was my first time participating in a conferences. I had a very great time there. I am looking forward to next year conferences."
+      - author: "Nguyen Nhu Thanh"
+        score: 5
+        text: "The event was amazing. I really enjoyed most of the sessions from the speakers who participated today, especially Michel Boretti's session on web redesign. He truly has great taste."
 subPages:
   - 2026-vietnam-hanoi/pages/informations
 ---

--- a/src/pages/events/[id]/index.astro
+++ b/src/pages/events/[id]/index.astro
@@ -46,6 +46,8 @@ import CustomBlockEventSlot from "@/components/CustomBlockEventSlot/index.astro"
 import { match } from "ts-pattern";
 import { getEntry } from "astro:content";
 import KeynoteSection from "@/components/KeynoteSection/index.astro";
+import EventRating from "@/components/EventRating/index.astro";
+import EventComment from "@/components/EventComment/index.astro";
 
 export async function getStaticPaths() {
   const allEvents = await getEventsCollection();
@@ -60,7 +62,7 @@ export async function getStaticPaths() {
           relatedEvents,
         },
       };
-    }),
+    })
   );
 }
 
@@ -70,10 +72,10 @@ const partners = await getEntries(event.data.partners ?? []);
 const speakers = await getEntries(event.data._computed.speakers ?? []);
 
 const coOrganizers = (await getEntries(event.data.coOrganizers ?? [])).filter(
-  (p) => !!p,
+  (p) => !!p
 );
 const sponsors = await getEntries(
-  (event.data.sponsors ?? []).map((s) => s.slug),
+  (event.data.sponsors ?? []).map((s) => s.slug)
 );
 
 const navItems = await getEventNavItems(event.id);
@@ -89,7 +91,7 @@ const location: Place | undefined = event.data.location
   : undefined;
 const ogImage = new URL(
   Astro.url.pathname + "/assets/og-image.jpg",
-  Astro.site,
+  Astro.site
 );
 
 const ctaTypes = getEventCtaTypes(event);
@@ -102,7 +104,7 @@ const ctaEventMetadata = {
 };
 
 const keynoteItems = (event.data.schedule?.items ?? []).filter(
-  (item) => item.type === "keynote",
+  (item) => item.type === "keynote"
 );
 
 const keynoteSection = await Promise.all(
@@ -114,11 +116,11 @@ const keynoteSection = await Promise.all(
       : [];
 
     return { item, talk, speakers };
-  }),
+  })
 );
 
 const validKeynotes = keynoteSection.filter(
-  ({ item, talk }) => talk && item.period,
+  ({ item, talk }) => talk && item.period
 );
 ---
 
@@ -156,6 +158,15 @@ const validKeynotes = keynoteSection.filter(
         name: speaker.data.name,
       })),
       ...(location && { location }),
+      ...(event.data.afterEventContent?.rating && {
+        aggregateRating: {
+          "@type": "AggregateRating" as const,
+          ratingValue: event.data.afterEventContent?.rating.score,
+          bestRating: 5,
+          worstRating: 1,
+          ratingCount: event.data.afterEventContent?.rating.count,
+        },
+      }),
     }}
   />
   <div
@@ -188,7 +199,7 @@ const validKeynotes = keynoteSection.filter(
                       class={cn(
                         coOrganizers.length === 1 && "w-32 md:w-52",
                         coOrganizers.length === 2 && "size-24 md:size-32",
-                        coOrganizers.length > 2 && "size-20 md:size-24",
+                        coOrganizers.length > 2 && "size-20 md:size-24"
                       )}
                       src={
                         coOrganizers.length === 1
@@ -285,7 +296,7 @@ const validKeynotes = keynoteSection.filter(
                 class={cn(
                   "w-24 max-w-none flex-none md:w-40",
                   sponsors.length <= 3 && "w-32 md:w-52",
-                  sponsors.length === 1 && "-my-8 w-48 md:w-64",
+                  sponsors.length === 1 && "-my-8 w-48 md:w-64"
                 )}
                 src={sponsor.data.logos.noBg}
                 alt={sponsor.data.name}
@@ -311,7 +322,7 @@ const validKeynotes = keynoteSection.filter(
         <div
           class={cn(
             "mx-auto flex w-full max-w-screen-lg flex-col gap-12",
-            event.data.afterEventContent.afterMovie && "max-w-screen-xl",
+            event.data.afterEventContent.afterMovie && "max-w-screen-xl"
           )}
         >
           <div class="text-center">
@@ -352,7 +363,7 @@ const validKeynotes = keynoteSection.filter(
                   class={cn(
                     "grid aspect-[640/426] gap-4",
                     (event.data.afterEventContent.photos.sources?.length ?? 0) >
-                      1 && "grid-cols-2",
+                      1 && "grid-cols-2"
                   )}
                 >
                   {event.data.afterEventContent.photos.sources?.map(
@@ -365,7 +376,7 @@ const validKeynotes = keynoteSection.filter(
                             (event.data.afterEventContent?.photos.sources
                               ?.length ?? 0) === 3 &&
                               index === 1 &&
-                              "row-span-2",
+                              "row-span-2"
                           )}
                           href={event.data.afterEventContent.photos.href}
                           target="_blank"
@@ -385,7 +396,7 @@ const validKeynotes = keynoteSection.filter(
                             (event.data.afterEventContent?.photos.sources
                               ?.length ?? 0) === 3 &&
                               index === 1 &&
-                              "row-span-2",
+                              "row-span-2"
                           )}
                         >
                           <Image
@@ -395,7 +406,7 @@ const validKeynotes = keynoteSection.filter(
                             width={800}
                           />
                         </div>
-                      ),
+                      )
                   )}
                 </div>
               )}
@@ -403,7 +414,7 @@ const validKeynotes = keynoteSection.filter(
               <div
                 class={cn(
                   "flex flex-col justify-center gap-4 sm:flex-row",
-                  event.data.afterEventContent.afterMovie && "md:justify-start",
+                  event.data.afterEventContent.afterMovie && "md:justify-start"
                 )}
               >
                 {event.data.afterEventContent.photos.href && (
@@ -413,7 +424,7 @@ const validKeynotes = keynoteSection.filter(
                     href={event.data.afterEventContent.photos.href}
                     class={cn(
                       buttonVariants({ size: "lg" }),
-                      "group gap-2 sm:max-w-48 md:flex-1",
+                      "group gap-2 sm:max-w-48 md:flex-1"
                     )}
                   >
                     Event Photos
@@ -427,7 +438,7 @@ const validKeynotes = keynoteSection.filter(
                     href={event.data.afterEventContent.vods.href}
                     class={cn(
                       buttonVariants({ size: "lg" }),
-                      "group gap-2 sm:max-w-48 md:flex-1",
+                      "group gap-2 sm:max-w-48 md:flex-1"
                     )}
                   >
                     All VODs
@@ -436,6 +447,24 @@ const validKeynotes = keynoteSection.filter(
                 )}
               </div>
             </div>
+          </div>
+          <div class="flex flex-col gap-4">
+            {event.data.afterEventContent?.rating && (
+              <EventRating
+                score={event.data.afterEventContent?.rating.score}
+                count={event.data.afterEventContent?.rating.count}
+                class="justify-center"
+              />
+            )}
+            {!!event.data.afterEventContent?.rating?.comments?.length && (
+              <div class="hide-scrollbar flex w-full gap-4 overflow-x-auto px-2 py-4 md:justify-center">
+                {event.data.afterEventContent.rating.comments
+                  .slice(0, 3)
+                  .map((comment) => (
+                    <EventComment comment={comment} />
+                  ))}
+              </div>
+            )}
           </div>
         </div>
       </div>
@@ -549,7 +578,7 @@ const validKeynotes = keynoteSection.filter(
               rel="noreferrer"
               class={cn(
                 buttonVariants({ size: "lg", variant: "secondary" }),
-                "max-xs:w-full",
+                "max-xs:w-full"
               )}
             >
               Call for Paper
@@ -558,7 +587,7 @@ const validKeynotes = keynoteSection.filter(
               href={lunalink(ROUTES["call-for-papers"].guidelines.__path, {})}
               class={cn(
                 buttonVariants({ size: "lg", variant: "ghost" }),
-                "max-xs:w-full",
+                "max-xs:w-full"
               )}
             >
               CFP How to & Guidelines
@@ -589,7 +618,7 @@ const validKeynotes = keynoteSection.filter(
   <div
     class={cn(
       "relative mx-auto flex w-full max-w-screen-sm flex-col gap-24 px-4 py-16 lg:max-w-screen-lg lg:flex-row lg:gap-12",
-      !speakers.length && "lg:max-w-screen-sm",
+      !speakers.length && "lg:max-w-screen-sm"
     )}
   >
     <div class="flex w-full flex-[1.3] flex-col gap-8 pb-4">
@@ -779,7 +808,7 @@ const validKeynotes = keynoteSection.filter(
       <div
         class={cn(
           buttonVariants({ size: "lg", variant: "secondary" }),
-          "max-xs:w-full",
+          "max-xs:w-full"
         )}
       >
         View Event Assets

--- a/src/pages/events/[id]/index.astro
+++ b/src/pages/events/[id]/index.astro
@@ -161,10 +161,10 @@ const validKeynotes = keynoteSection.filter(
       ...(event.data.afterEventContent?.rating && {
         aggregateRating: {
           "@type": "AggregateRating" as const,
-          ratingValue: event.data.afterEventContent?.rating.averageScore,
+          ratingValue: event.data.afterEventContent.rating.averageScore,
           bestRating: 5,
           worstRating: 1,
-          ratingCount: event.data.afterEventContent?.rating.count,
+          ratingCount: event.data.afterEventContent.rating.count,
         },
       }),
     }}

--- a/src/pages/events/[id]/index.astro
+++ b/src/pages/events/[id]/index.astro
@@ -62,7 +62,7 @@ export async function getStaticPaths() {
           relatedEvents,
         },
       };
-    })
+    }),
   );
 }
 
@@ -72,10 +72,10 @@ const partners = await getEntries(event.data.partners ?? []);
 const speakers = await getEntries(event.data._computed.speakers ?? []);
 
 const coOrganizers = (await getEntries(event.data.coOrganizers ?? [])).filter(
-  (p) => !!p
+  (p) => !!p,
 );
 const sponsors = await getEntries(
-  (event.data.sponsors ?? []).map((s) => s.slug)
+  (event.data.sponsors ?? []).map((s) => s.slug),
 );
 
 const navItems = await getEventNavItems(event.id);
@@ -91,7 +91,7 @@ const location: Place | undefined = event.data.location
   : undefined;
 const ogImage = new URL(
   Astro.url.pathname + "/assets/og-image.jpg",
-  Astro.site
+  Astro.site,
 );
 
 const ctaTypes = getEventCtaTypes(event);
@@ -104,7 +104,7 @@ const ctaEventMetadata = {
 };
 
 const keynoteItems = (event.data.schedule?.items ?? []).filter(
-  (item) => item.type === "keynote"
+  (item) => item.type === "keynote",
 );
 
 const keynoteSection = await Promise.all(
@@ -116,11 +116,11 @@ const keynoteSection = await Promise.all(
       : [];
 
     return { item, talk, speakers };
-  })
+  }),
 );
 
 const validKeynotes = keynoteSection.filter(
-  ({ item, talk }) => talk && item.period
+  ({ item, talk }) => talk && item.period,
 );
 ---
 
@@ -161,7 +161,7 @@ const validKeynotes = keynoteSection.filter(
       ...(event.data.afterEventContent?.rating && {
         aggregateRating: {
           "@type": "AggregateRating" as const,
-          ratingValue: event.data.afterEventContent?.rating.score,
+          ratingValue: event.data.afterEventContent?.rating.averageScore,
           bestRating: 5,
           worstRating: 1,
           ratingCount: event.data.afterEventContent?.rating.count,
@@ -199,7 +199,7 @@ const validKeynotes = keynoteSection.filter(
                       class={cn(
                         coOrganizers.length === 1 && "w-32 md:w-52",
                         coOrganizers.length === 2 && "size-24 md:size-32",
-                        coOrganizers.length > 2 && "size-20 md:size-24"
+                        coOrganizers.length > 2 && "size-20 md:size-24",
                       )}
                       src={
                         coOrganizers.length === 1
@@ -296,7 +296,7 @@ const validKeynotes = keynoteSection.filter(
                 class={cn(
                   "w-24 max-w-none flex-none md:w-40",
                   sponsors.length <= 3 && "w-32 md:w-52",
-                  sponsors.length === 1 && "-my-8 w-48 md:w-64"
+                  sponsors.length === 1 && "-my-8 w-48 md:w-64",
                 )}
                 src={sponsor.data.logos.noBg}
                 alt={sponsor.data.name}
@@ -322,7 +322,7 @@ const validKeynotes = keynoteSection.filter(
         <div
           class={cn(
             "mx-auto flex w-full max-w-screen-lg flex-col gap-12",
-            event.data.afterEventContent.afterMovie && "max-w-screen-xl"
+            event.data.afterEventContent.afterMovie && "max-w-screen-xl",
           )}
         >
           <div class="text-center">
@@ -363,7 +363,7 @@ const validKeynotes = keynoteSection.filter(
                   class={cn(
                     "grid aspect-[640/426] gap-4",
                     (event.data.afterEventContent.photos.sources?.length ?? 0) >
-                      1 && "grid-cols-2"
+                      1 && "grid-cols-2",
                   )}
                 >
                   {event.data.afterEventContent.photos.sources?.map(
@@ -376,7 +376,7 @@ const validKeynotes = keynoteSection.filter(
                             (event.data.afterEventContent?.photos.sources
                               ?.length ?? 0) === 3 &&
                               index === 1 &&
-                              "row-span-2"
+                              "row-span-2",
                           )}
                           href={event.data.afterEventContent.photos.href}
                           target="_blank"
@@ -396,7 +396,7 @@ const validKeynotes = keynoteSection.filter(
                             (event.data.afterEventContent?.photos.sources
                               ?.length ?? 0) === 3 &&
                               index === 1 &&
-                              "row-span-2"
+                              "row-span-2",
                           )}
                         >
                           <Image
@@ -406,7 +406,7 @@ const validKeynotes = keynoteSection.filter(
                             width={800}
                           />
                         </div>
-                      )
+                      ),
                   )}
                 </div>
               )}
@@ -414,7 +414,7 @@ const validKeynotes = keynoteSection.filter(
               <div
                 class={cn(
                   "flex flex-col justify-center gap-4 sm:flex-row",
-                  event.data.afterEventContent.afterMovie && "md:justify-start"
+                  event.data.afterEventContent.afterMovie && "md:justify-start",
                 )}
               >
                 {event.data.afterEventContent.photos.href && (
@@ -424,7 +424,7 @@ const validKeynotes = keynoteSection.filter(
                     href={event.data.afterEventContent.photos.href}
                     class={cn(
                       buttonVariants({ size: "lg" }),
-                      "group gap-2 sm:max-w-48 md:flex-1"
+                      "group gap-2 sm:max-w-48 md:flex-1",
                     )}
                   >
                     Event Photos
@@ -438,7 +438,7 @@ const validKeynotes = keynoteSection.filter(
                     href={event.data.afterEventContent.vods.href}
                     class={cn(
                       buttonVariants({ size: "lg" }),
-                      "group gap-2 sm:max-w-48 md:flex-1"
+                      "group gap-2 sm:max-w-48 md:flex-1",
                     )}
                   >
                     All VODs
@@ -451,7 +451,7 @@ const validKeynotes = keynoteSection.filter(
           <div class="flex flex-col gap-4">
             {event.data.afterEventContent?.rating && (
               <EventRating
-                score={event.data.afterEventContent?.rating.score}
+                averageScore={event.data.afterEventContent?.rating.averageScore}
                 count={event.data.afterEventContent?.rating.count}
                 class="justify-center"
               />
@@ -578,7 +578,7 @@ const validKeynotes = keynoteSection.filter(
               rel="noreferrer"
               class={cn(
                 buttonVariants({ size: "lg", variant: "secondary" }),
-                "max-xs:w-full"
+                "max-xs:w-full",
               )}
             >
               Call for Paper
@@ -587,7 +587,7 @@ const validKeynotes = keynoteSection.filter(
               href={lunalink(ROUTES["call-for-papers"].guidelines.__path, {})}
               class={cn(
                 buttonVariants({ size: "lg", variant: "ghost" }),
-                "max-xs:w-full"
+                "max-xs:w-full",
               )}
             >
               CFP How to & Guidelines
@@ -618,7 +618,7 @@ const validKeynotes = keynoteSection.filter(
   <div
     class={cn(
       "relative mx-auto flex w-full max-w-screen-sm flex-col gap-24 px-4 py-16 lg:max-w-screen-lg lg:flex-row lg:gap-12",
-      !speakers.length && "lg:max-w-screen-sm"
+      !speakers.length && "lg:max-w-screen-sm",
     )}
   >
     <div class="flex w-full flex-[1.3] flex-col gap-8 pb-4">
@@ -808,7 +808,7 @@ const validKeynotes = keynoteSection.filter(
       <div
         class={cn(
           buttonVariants({ size: "lg", variant: "secondary" }),
-          "max-xs:w-full"
+          "max-xs:w-full",
         )}
       >
         View Event Assets

--- a/src/schemas/events.ts
+++ b/src/schemas/events.ts
@@ -74,7 +74,7 @@ export const zEventBasicInfo = ({ image }: SchemaContext) =>
         }),
         rating: z
           .object({
-            score: z.number().min(1).max(5),
+            averageScore: z.number().min(1).max(5),
             count: z.number().int().positive(),
             comments: z
               .array(

--- a/src/schemas/events.ts
+++ b/src/schemas/events.ts
@@ -72,6 +72,21 @@ export const zEventBasicInfo = ({ image }: SchemaContext) =>
             .max(4)
             .optional(),
         }),
+        rating: z
+          .object({
+            score: z.number().min(1).max(5),
+            count: z.number().int().positive(),
+            comments: z
+              .array(
+                z.object({
+                  author: z.string(),
+                  text: z.string(),
+                  score: z.number().min(1).max(5),
+                }),
+              )
+              .optional(),
+          })
+          .optional(),
       })
       .optional(),
   });

--- a/src/schemas/events.ts
+++ b/src/schemas/events.ts
@@ -79,8 +79,8 @@ export const zEventBasicInfo = ({ image }: SchemaContext) =>
             comments: z
               .array(
                 z.object({
-                  author: z.string(),
-                  text: z.string(),
+                  author: z.string().min(1),
+                  text: z.string().min(1),
                   score: z.number().min(1).max(5),
                 }),
               )


### PR DESCRIPTION
## Summary
- Add `rating` schema (score, count, comments) inside `afterEventContent` for events
- Create `StarRating`, `EventRating`, and `EventComment` Astro components to display star ratings and attendee quotes
- Add Schema.org `AggregateRating` structured data (JSON-LD) for Google rich results
- Add rating data for Hanoi 2026 (10 comments from Luma feedback) and Tunis 2025
- Comment cards scroll horizontally, centered on desktop, left-aligned on mobile

## Test plan
- [x] Check Hanoi 2026 event page displays rating + comment cards in After Event Insights
- [x] Check Tunis 2025 event page displays rating without comments
- [x] Verify events without rating data show no rating UI
- [x] Inspect page source for `aggregateRating` in JSON-LD
- [x] Test mobile scroll on comment cards (should start from left)

Closes #587 
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event pages now show aggregate ratings with average score and rating count.
  * An “After Event” section displays attendee comments in a horizontally scrollable row (up to three shown).
  * Consistent star rating visuals added, supporting small and medium sizes for ratings and comments.

* **Content**
  * Several event entries updated to include ratings and attendee comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->