### PR TITLE
feat: add aliases for registration and tickets assets

### DIFF
--- a/src/assets/consts.ts
+++ b/src/assets/consts.ts
@@ -24,6 +24,10 @@ export const ASSET_CATEGORIES = [
 
 export type AssetCategoryId = (typeof ASSET_CATEGORIES)[number]["id"];
 
+export const CATEGORY_ALIASES: Partial<Record<AssetCategoryId, string[]>> = {
+  tickets: ["tickets", "registration"],
+};
+
 export const EXCLUDED_CATEGORIES_BY_TYPE: Record<
   CollectionEntry<"events">["data"]["type"],
   AssetCategoryId[]

--- a/src/assets/consts.ts
+++ b/src/assets/consts.ts
@@ -25,7 +25,7 @@ export const ASSET_CATEGORIES = [
 export type AssetCategoryId = (typeof ASSET_CATEGORIES)[number]["id"];
 
 export const CATEGORY_ALIASES: Partial<Record<AssetCategoryId, string[]>> = {
-  tickets: ["tickets", "registration"],
+  tickets: ["registration"],
 };
 
 export const EXCLUDED_CATEGORIES_BY_TYPE: Record<

--- a/src/pages/events/[id]/assets/_utils.ts
+++ b/src/pages/events/[id]/assets/_utils.ts
@@ -1,5 +1,6 @@
 import {
   ASSET_CATEGORIES,
+  CATEGORY_ALIASES,
   EXCLUDED_CATEGORIES_BY_TYPE,
   type AssetCategoryId,
 } from "@/assets/consts";
@@ -78,9 +79,11 @@ export const getEventAssetsSources = (event: CollectionEntry<"events">) => {
 };
 
 export const categorize = (path: string) =>
-  ASSET_CATEGORIES.find(
-    (category) => category.id !== "other" && path.includes(category.id),
-  )?.id ?? "other";
+  ASSET_CATEGORIES.find((category) => {
+    if (category.id === "other") return false;
+    const patterns = CATEGORY_ALIASES[category.id] ?? [category.id];
+    return patterns.some((pattern) => path.includes(pattern));
+  })?.id ?? "other";
 
 const getOppositeSuffixes = (
   eventType: CollectionEntry<"events">["data"]["type"],

--- a/src/pages/events/[id]/assets/_utils.ts
+++ b/src/pages/events/[id]/assets/_utils.ts
@@ -81,7 +81,7 @@ export const getEventAssetsSources = (event: CollectionEntry<"events">) => {
 export const categorize = (path: string) =>
   ASSET_CATEGORIES.find((category) => {
     if (category.id === "other") return false;
-    const patterns = CATEGORY_ALIASES[category.id] ?? [category.id];
+    const patterns = [category.id, ...(CATEGORY_ALIASES[category.id] ?? [])];
     return patterns.some((pattern) => path.includes(pattern));
   })?.id ?? "other";
 


### PR DESCRIPTION
We can now have aliases to avoid having registration in "others" category for example so it will be download with the rest of the assets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added category aliases to improve asset discovery and organization. Assets can now be recognized by multiple names; e.g., the "tickets" category also accepts "registration".
  * Matching now prioritizes explicit category aliases (excluding the generic "other" group) while still falling back to "other" when no match is found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->