### PR TITLE
feat: add mandatory lang key to people schema for bio language

### DIFF
--- a/src/components/PeopleWithDescription/index.astro
+++ b/src/components/PeopleWithDescription/index.astro
@@ -7,6 +7,7 @@ import { ROUTES } from "@/routes.gen";
 import { SOCIALS_TYPE_MAP } from "@/content/socials";
 import { render } from "astro:content";
 import Prose from "@/components/Prose/index.astro";
+import { lang } from "@/lib/lang";
 
 interface Props {
   organizer: CollectionEntry<"people">;
@@ -75,7 +76,7 @@ const { Content } = await render(organizer);
         </ul>
       )
     }
-    <Prose class="prose-sm hidden md:block">
+    <Prose class="prose-sm hidden md:block" lang={lang(organizer.data.lang)}>
       <Content />
     </Prose>
   </div>

--- a/src/components/PeopleWithDescription/index.astro
+++ b/src/components/PeopleWithDescription/index.astro
@@ -76,7 +76,7 @@ const { Content } = await render(organizer);
         </ul>
       )
     }
-    <Prose class="prose-sm hidden md:block" lang={lang(organizer.data.lang)}>
+    <Prose class="prose-sm hidden md:block" lang={lang(organizer.data.bioLang)}>
       <Content />
     </Prose>
   </div>

--- a/src/components/Prose/index.astro
+++ b/src/components/Prose/index.astro
@@ -3,11 +3,13 @@ import { cn } from "@/lib/utils-client";
 
 interface Props {
   class?: string;
+  lang?: string;
 }
-const { class: className } = Astro.props;
+const { class: className, lang } = Astro.props;
 ---
 
 <div
+  lang={lang}
   class={cn(
     // Base
     "prose prose-invert w-full",

--- a/src/content/people/abdelkrim-marchani/index.mdx
+++ b/src/content/people/abdelkrim-marchani/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Abdelkrim Marchani
 avatar: ./abdelkrim-marchani.jpg
 job: Vice President of the Rouen Normandy metropolitan area

--- a/src/content/people/abdelkrim-marchani/index.mdx
+++ b/src/content/people/abdelkrim-marchani/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Abdelkrim Marchani
 avatar: ./abdelkrim-marchani.jpg
 job: Vice President of the Rouen Normandy metropolitan area

--- a/src/content/people/adaku-nwakanma/index.mdx
+++ b/src/content/people/adaku-nwakanma/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Adaku Nwakanma
 avatar: ./adaku-nwakanma.jpeg
 job: UI/UX Designer

--- a/src/content/people/adaku-nwakanma/index.mdx
+++ b/src/content/people/adaku-nwakanma/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Adaku Nwakanma
 avatar: ./adaku-nwakanma.jpeg
 job: UI/UX Designer

--- a/src/content/people/ahmed-ben-jbara/index.mdx
+++ b/src/content/people/ahmed-ben-jbara/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Ahmed Ben Jbara
 avatar: ./ahmed-ben-jbara.jpg
 job: 3D Artist & Filmmaker

--- a/src/content/people/ahmed-ben-jbara/index.mdx
+++ b/src/content/people/ahmed-ben-jbara/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Ahmed Ben Jbara
 avatar: ./ahmed-ben-jbara.jpg
 job: 3D Artist & Filmmaker

--- a/src/content/people/alexandra-pituru/index.mdx
+++ b/src/content/people/alexandra-pituru/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Alexandra Pituru
 avatar: ./alexandra-pituru.jpg
 job: UI/UX Designer

--- a/src/content/people/alexandra-pituru/index.mdx
+++ b/src/content/people/alexandra-pituru/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Alexandra Pituru
 avatar: ./alexandra-pituru.jpg
 job: UI/UX Designer

--- a/src/content/people/alexandre-burgoni/index.mdx
+++ b/src/content/people/alexandre-burgoni/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Alexandre Burgoni
 avatar: ./alexandre-burgoni.jpg
 job: Site Reliability Engineer

--- a/src/content/people/alexandre-burgoni/index.mdx
+++ b/src/content/people/alexandre-burgoni/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Alexandre Burgoni
 avatar: ./alexandre-burgoni.jpg
 job: Site Reliability Engineer

--- a/src/content/people/alexis-stefanski/index.mdx
+++ b/src/content/people/alexis-stefanski/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Alexis Stefanski
 avatar: ./alexis-stefanski.jpg
 job: Tech Lead and developer

--- a/src/content/people/alexis-stefanski/index.mdx
+++ b/src/content/people/alexis-stefanski/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Alexis Stefanski
 avatar: ./alexis-stefanski.jpg
 job: Tech Lead and developer

--- a/src/content/people/amine-ziraoui/index.mdx
+++ b/src/content/people/amine-ziraoui/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Amine Ziraoui
 avatar: ./amine-ziraoui.jpg
 job: Founder

--- a/src/content/people/amine-ziraoui/index.mdx
+++ b/src/content/people/amine-ziraoui/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Amine Ziraoui
 avatar: ./amine-ziraoui.jpg
 job: Founder

--- a/src/content/people/andrey-sitnik/index.mdx
+++ b/src/content/people/andrey-sitnik/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Andrey Sitnik
 avatar: ./andrey-sitnik.jpg
 job: Creator of Autoprefixer, PostCSS, Browserslist

--- a/src/content/people/andrey-sitnik/index.mdx
+++ b/src/content/people/andrey-sitnik/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Andrey Sitnik
 avatar: ./andrey-sitnik.jpg
 job: Creator of Autoprefixer, PostCSS, Browserslist

--- a/src/content/people/antoine-mazure/index.mdx
+++ b/src/content/people/antoine-mazure/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: french
+bioLang: french
 name: Antoine Mazure
 job: Software Engineer, Tribe Leader and Trainer
 avatar: ./antoine-mazure.jpg

--- a/src/content/people/antoine-mazure/index.mdx
+++ b/src/content/people/antoine-mazure/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: french
 name: Antoine Mazure
 job: Software Engineer, Tribe Leader and Trainer
 avatar: ./antoine-mazure.jpg

--- a/src/content/people/arnaud-mary/index.mdx
+++ b/src/content/people/arnaud-mary/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: french
 name: Arnaud Mary
 avatar: ./arnaud-mary.jpg
 job: Lead Chapter Full Stack

--- a/src/content/people/arnaud-mary/index.mdx
+++ b/src/content/people/arnaud-mary/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: french
+bioLang: french
 name: Arnaud Mary
 avatar: ./arnaud-mary.jpg
 job: Lead Chapter Full Stack

--- a/src/content/people/atef-maddouri/index.mdx
+++ b/src/content/people/atef-maddouri/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: french
+bioLang: french
 name: Atef Maddouri
 avatar: ./atef-maddouri.jpg
 company:

--- a/src/content/people/atef-maddouri/index.mdx
+++ b/src/content/people/atef-maddouri/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: french
 name: Atef Maddouri
 avatar: ./atef-maddouri.jpg
 company:

--- a/src/content/people/ayoub-alouane/index.mdx
+++ b/src/content/people/ayoub-alouane/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Ayoub Alouane
 avatar: ./ayoub-alouane.jpg
 job: DevRel and TechLead

--- a/src/content/people/ayoub-alouane/index.mdx
+++ b/src/content/people/ayoub-alouane/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Ayoub Alouane
 avatar: ./ayoub-alouane.jpg
 job: DevRel and TechLead

--- a/src/content/people/aziz-becha/index.mdx
+++ b/src/content/people/aziz-becha/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Aziz Becha
 avatar: ./aziz-becha.jpg
 job: Software Developer

--- a/src/content/people/aziz-becha/index.mdx
+++ b/src/content/people/aziz-becha/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Aziz Becha
 avatar: ./aziz-becha.jpg
 job: Software Developer

--- a/src/content/people/aziz-ouertani/index.mdx
+++ b/src/content/people/aziz-ouertani/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Aziz Ouertani
 avatar: ./aziz-ouertani.jpg
 job: Sales & Backend developer

--- a/src/content/people/aziz-ouertani/index.mdx
+++ b/src/content/people/aziz-ouertani/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Aziz Ouertani
 avatar: ./aziz-ouertani.jpg
 job: Sales & Backend developer

--- a/src/content/people/ba-ngoc/index.mdx
+++ b/src/content/people/ba-ngoc/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Ba Ngoc
 avatar: ./ba-ngoc.jpg
 job: Founder & Google Developers Expert in Machine Learning

--- a/src/content/people/ba-ngoc/index.mdx
+++ b/src/content/people/ba-ngoc/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Ba Ngoc
 avatar: ./ba-ngoc.jpg
 job: Founder & Google Developers Expert in Machine Learning

--- a/src/content/people/baptiste-kervargant/index.mdx
+++ b/src/content/people/baptiste-kervargant/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Baptiste Kervargant
 avatar: baptiste-kervargant.jpg
 job: UX/UI designer

--- a/src/content/people/baptiste-kervargant/index.mdx
+++ b/src/content/people/baptiste-kervargant/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Baptiste Kervargant
 avatar: baptiste-kervargant.jpg
 job: UX/UI designer

--- a/src/content/people/baptiste-lemoine/index.mdx
+++ b/src/content/people/baptiste-lemoine/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Baptiste Lemoine
 job: Cipherbliss CEO
 avatar: ./cover.jpg

--- a/src/content/people/baptiste-lemoine/index.mdx
+++ b/src/content/people/baptiste-lemoine/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Baptiste Lemoine
 job: Cipherbliss CEO
 avatar: ./cover.jpg

--- a/src/content/people/cedric-due/index.mdx
+++ b/src/content/people/cedric-due/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Cédric Dué
 avatar: ./cedric-due.jpg
 country: france

--- a/src/content/people/cedric-due/index.mdx
+++ b/src/content/people/cedric-due/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Cédric Dué
 avatar: ./cedric-due.jpg
 country: france

--- a/src/content/people/clement-michel/index.mdx
+++ b/src/content/people/clement-michel/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Clément Michel
 avatar: ./clement-michel.jpg
 job: Cybersecurity expert

--- a/src/content/people/clement-michel/index.mdx
+++ b/src/content/people/clement-michel/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Clément Michel
 avatar: ./clement-michel.jpg
 job: Cybersecurity expert

--- a/src/content/people/daryl-avila-bonnet/index.mdx
+++ b/src/content/people/daryl-avila-bonnet/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Daryl Avila Bonnet
 avatar: ./daryl-avila-bonnet.jpg
 job: UX/UI Designer

--- a/src/content/people/daryl-avila-bonnet/index.mdx
+++ b/src/content/people/daryl-avila-bonnet/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Daryl Avila Bonnet
 avatar: ./daryl-avila-bonnet.jpg
 job: UX/UI Designer

--- a/src/content/people/david-gomes/index.mdx
+++ b/src/content/people/david-gomes/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: David Gomes
 avatar: ./david-gomes.jpg
 job: Software Engineer

--- a/src/content/people/david-gomes/index.mdx
+++ b/src/content/people/david-gomes/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: David Gomes
 avatar: ./david-gomes.jpg
 job: Software Engineer

--- a/src/content/people/eason-chai/index.mdx
+++ b/src/content/people/eason-chai/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Eason Chai
 avatar: ./eason-chai.jpg
 job: Founder at ELVTD

--- a/src/content/people/eason-chai/index.mdx
+++ b/src/content/people/eason-chai/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Eason Chai
 avatar: ./eason-chai.jpg
 job: Founder at ELVTD

--- a/src/content/people/elea-viscat-provost/index.mdx
+++ b/src/content/people/elea-viscat-provost/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: "Eléa Viscat--Provost"
 avatar: ./elea-viscat-provost.jpg
 job: Community Manager

--- a/src/content/people/elea-viscat-provost/index.mdx
+++ b/src/content/people/elea-viscat-provost/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: "Eléa Viscat--Provost"
 avatar: ./elea-viscat-provost.jpg
 job: Community Manager

--- a/src/content/people/elian-van-cutsem/index.mdx
+++ b/src/content/people/elian-van-cutsem/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Elian Van Cutsem
 avatar: ./elian-van-cutsem.jpg
 job: Lead Developer Relations, React Bricks

--- a/src/content/people/elian-van-cutsem/index.mdx
+++ b/src/content/people/elian-van-cutsem/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Elian Van Cutsem
 avatar: ./elian-van-cutsem.jpg
 job: Lead Developer Relations, React Bricks

--- a/src/content/people/erez-david-shtayman/index.mdx
+++ b/src/content/people/erez-david-shtayman/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Erez David Shtayman
 avatar: ./erez-david-shtayman.jpg
 job: Software Engineering Manager

--- a/src/content/people/erez-david-shtayman/index.mdx
+++ b/src/content/people/erez-david-shtayman/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Erez David Shtayman
 avatar: ./erez-david-shtayman.jpg
 job: Software Engineering Manager

--- a/src/content/people/erik-le/index.mdx
+++ b/src/content/people/erik-le/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Erik Le
 avatar: ./erik-le.jpg
 job: Founder and CEO

--- a/src/content/people/erik-le/index.mdx
+++ b/src/content/people/erik-le/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Erik Le
 avatar: ./erik-le.jpg
 job: Founder and CEO

--- a/src/content/people/erwan-rougeux/index.mdx
+++ b/src/content/people/erwan-rougeux/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Erwan Rougeux
 avatar: ./erwan-rougeux.jpg
 country: france

--- a/src/content/people/erwan-rougeux/index.mdx
+++ b/src/content/people/erwan-rougeux/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Erwan Rougeux
 avatar: ./erwan-rougeux.jpg
 country: france

--- a/src/content/people/evelyn-nguyen/index.mdx
+++ b/src/content/people/evelyn-nguyen/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Evelyn Nguyen
 avatar: ./evelyn-nguyen.jpg
 job: Business Development Manager

--- a/src/content/people/evelyn-nguyen/index.mdx
+++ b/src/content/people/evelyn-nguyen/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Evelyn Nguyen
 avatar: ./evelyn-nguyen.jpg
 job: Business Development Manager

--- a/src/content/people/eya-laouini/index.mdx
+++ b/src/content/people/eya-laouini/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Eya Laouini
 avatar: ./eya-laouini.jpg
 job: AI Engineer & Google Developer Expert

--- a/src/content/people/eya-laouini/index.mdx
+++ b/src/content/people/eya-laouini/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Eya Laouini
 avatar: ./eya-laouini.jpg
 job: AI Engineer & Google Developer Expert

--- a/src/content/people/francois-best/index.mdx
+++ b/src/content/people/francois-best/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: François Best
 avatar: ./francois-best.png
 job: Web developer and creator of nuqs

--- a/src/content/people/francois-best/index.mdx
+++ b/src/content/people/francois-best/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: François Best
 avatar: ./francois-best.png
 job: Web developer and creator of nuqs

--- a/src/content/people/frederic-bisson/index.mdx
+++ b/src/content/people/frederic-bisson/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Frédéric Bisson
 avatar: ./frederic-bisson.jpg
 job: Web developer

--- a/src/content/people/frederic-bisson/index.mdx
+++ b/src/content/people/frederic-bisson/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Frédéric Bisson
 avatar: ./frederic-bisson.jpg
 job: Web developer

--- a/src/content/people/gabriel-pichot/index.mdx
+++ b/src/content/people/gabriel-pichot/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Gabriel Pichot
 avatar: ./gabriel-pichot.jpg
 job: Formateur React & Web | IT Engineer

--- a/src/content/people/gabriel-pichot/index.mdx
+++ b/src/content/people/gabriel-pichot/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Gabriel Pichot
 avatar: ./gabriel-pichot.jpg
 job: Formateur React & Web | IT Engineer

--- a/src/content/people/geert-theys/index.mdx
+++ b/src/content/people/geert-theys/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Geert Theys
 avatar: ./geert-theys.jpeg
 job: Head of FinTech

--- a/src/content/people/geert-theys/index.mdx
+++ b/src/content/people/geert-theys/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Geert Theys
 avatar: ./geert-theys.jpeg
 job: Head of FinTech

--- a/src/content/people/hend-fellah/index.mdx
+++ b/src/content/people/hend-fellah/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Hend Fellah
 avatar: ./hend-fellah.jpg
 job: Company manager

--- a/src/content/people/hend-fellah/index.mdx
+++ b/src/content/people/hend-fellah/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Hend Fellah
 avatar: ./hend-fellah.jpg
 job: Company manager

--- a/src/content/people/houssem-balti/index.mdx
+++ b/src/content/people/houssem-balti/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Houssem Balti
 avatar: houssem.png
 job: Web developer

--- a/src/content/people/houssem-balti/index.mdx
+++ b/src/content/people/houssem-balti/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Houssem Balti
 avatar: houssem.png
 job: Web developer

--- a/src/content/people/hugo-gresse/index.mdx
+++ b/src/content/people/hugo-gresse/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Hugo Gresse
 avatar: hugo-gresse.jpg
 job: Mobile developer

--- a/src/content/people/hugo-gresse/index.mdx
+++ b/src/content/people/hugo-gresse/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Hugo Gresse
 avatar: hugo-gresse.jpg
 job: Mobile developer

--- a/src/content/people/hugo-kwiatkowski/index.mdx
+++ b/src/content/people/hugo-kwiatkowski/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Hugo Kwiatkowski
 job: Student in notarial law at Rouen university
 socials:

--- a/src/content/people/hugo-kwiatkowski/index.mdx
+++ b/src/content/people/hugo-kwiatkowski/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Hugo Kwiatkowski
 job: Student in notarial law at Rouen university
 socials:

--- a/src/content/people/hugo-perard/index.mdx
+++ b/src/content/people/hugo-perard/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Hugo Pérard
 avatar: ./hugo-perard.jpg
 job: Lead front developer

--- a/src/content/people/hugo-perard/index.mdx
+++ b/src/content/people/hugo-perard/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Hugo Pérard
 avatar: ./hugo-perard.jpg
 job: Lead front developer

--- a/src/content/people/hugo-siow/index.mdx
+++ b/src/content/people/hugo-siow/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Hugo Siow
 avatar: hugo-siow.jpg
 job: ""

--- a/src/content/people/hugo-siow/index.mdx
+++ b/src/content/people/hugo-siow/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Hugo Siow
 avatar: hugo-siow.jpg
 job: ""

--- a/src/content/people/idriss-neumann/index.mdx
+++ b/src/content/people/idriss-neumann/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: french
 name: Idriss Neumann
 avatar: ./idriss-neumann.jpg
 job: CEO and Engineer

--- a/src/content/people/idriss-neumann/index.mdx
+++ b/src/content/people/idriss-neumann/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: french
+bioLang: french
 name: Idriss Neumann
 avatar: ./idriss-neumann.jpg
 job: CEO and Engineer

--- a/src/content/people/ioun-nirach/index.mdx
+++ b/src/content/people/ioun-nirach/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Ioun Nirach
 avatar: ./ioun-nirach.jpeg
 job: Frontend Developer

--- a/src/content/people/ioun-nirach/index.mdx
+++ b/src/content/people/ioun-nirach/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Ioun Nirach
 avatar: ./ioun-nirach.jpeg
 job: Frontend Developer

--- a/src/content/people/ivan-dalmet/index.mdx
+++ b/src/content/people/ivan-dalmet/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Ivan Dalmet
 avatar: ./ivan-dalmet.jpg
 job: Co-founder and Lead Designer

--- a/src/content/people/ivan-dalmet/index.mdx
+++ b/src/content/people/ivan-dalmet/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Ivan Dalmet
 avatar: ./ivan-dalmet.jpg
 job: Co-founder and Lead Designer

--- a/src/content/people/jean-baptiste-briant/index.mdx
+++ b/src/content/people/jean-baptiste-briant/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Jean-Baptiste Briant
 avatar: ./jean-baptiste-briant.png
 job: CEO and baseBuilding system expert

--- a/src/content/people/jean-baptiste-briant/index.mdx
+++ b/src/content/people/jean-baptiste-briant/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Jean-Baptiste Briant
 avatar: ./jean-baptiste-briant.png
 job: CEO and baseBuilding system expert

--- a/src/content/people/jeanne-grenet/index.mdx
+++ b/src/content/people/jeanne-grenet/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Jeanne Grenet
 avatar: ./jeanne-grenet.jpg
 job: Web Developer

--- a/src/content/people/jeanne-grenet/index.mdx
+++ b/src/content/people/jeanne-grenet/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Jeanne Grenet
 avatar: ./jeanne-grenet.jpg
 job: Web Developer

--- a/src/content/people/jeff-sandhu/index.mdx
+++ b/src/content/people/jeff-sandhu/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Jeff Sandhu
 job: CEO, Sunway FutureX DI 42 Malaysia
 avatar: ./jeff-sandhu.jpg

--- a/src/content/people/jeff-sandhu/index.mdx
+++ b/src/content/people/jeff-sandhu/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Jeff Sandhu
 job: CEO, Sunway FutureX DI 42 Malaysia
 avatar: ./jeff-sandhu.jpg

--- a/src/content/people/jihene-mejri/index.mdx
+++ b/src/content/people/jihene-mejri/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: french
+bioLang: french
 name: Jihène Mejri
 avatar: ./jihene-mejri.jpg
 job: Chapter lead

--- a/src/content/people/jihene-mejri/index.mdx
+++ b/src/content/people/jihene-mejri/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: french
 name: Jihène Mejri
 avatar: ./jihene-mejri.jpg
 job: Chapter lead

--- a/src/content/people/joong-sern-yap/index.mdx
+++ b/src/content/people/joong-sern-yap/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name:  Joong Sern (Johnson) Yap
 job: Strategic Growth & Development Manager
 avatar: ./joong-sern-yap.jpg

--- a/src/content/people/joong-sern-yap/index.mdx
+++ b/src/content/people/joong-sern-yap/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name:  Joong Sern (Johnson) Yap
 job: Strategic Growth & Development Manager
 avatar: ./joong-sern-yap.jpg

--- a/src/content/people/kan-pawarisson/index.mdx
+++ b/src/content/people/kan-pawarisson/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Kan Pawarisson
 avatar: ./kan-pawarisson.jpeg
 job: Co-Founder, Head of Foxbith Product Team

--- a/src/content/people/kan-pawarisson/index.mdx
+++ b/src/content/people/kan-pawarisson/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Kan Pawarisson
 avatar: ./kan-pawarisson.jpeg
 job: Co-Founder, Head of Foxbith Product Team

--- a/src/content/people/kelvin-lai/index.mdx
+++ b/src/content/people/kelvin-lai/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Kelvin Lai
 avatar: kelvin-lai.jpg
 job: ""

--- a/src/content/people/kelvin-lai/index.mdx
+++ b/src/content/people/kelvin-lai/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Kelvin Lai
 avatar: kelvin-lai.jpg
 job: ""

--- a/src/content/people/luis-rubiera/index.mdx
+++ b/src/content/people/luis-rubiera/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Luis Rubiera
 avatar: ./luis-rubiera.jpg
 job: Lead Developer

--- a/src/content/people/luis-rubiera/index.mdx
+++ b/src/content/people/luis-rubiera/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Luis Rubiera
 avatar: ./luis-rubiera.jpg
 job: Lead Developer

--- a/src/content/people/lyn-ai/index.mdx
+++ b/src/content/people/lyn-ai/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Lyn Ai
 job: Growth Hacker | Digital Marketer
 avatar: ./lyn-ai.jpg

--- a/src/content/people/lyn-ai/index.mdx
+++ b/src/content/people/lyn-ai/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Lyn Ai
 job: Growth Hacker | Digital Marketer
 avatar: ./lyn-ai.jpg

--- a/src/content/people/magali-de-labareyre/index.mdx
+++ b/src/content/people/magali-de-labareyre/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: french
+bioLang: french
 name: Magali de Labareyre
 job: HR engineer
 avatar: ./magali-de-labareyre.jpg

--- a/src/content/people/magali-de-labareyre/index.mdx
+++ b/src/content/people/magali-de-labareyre/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: french
 name: Magali de Labareyre
 job: HR engineer
 avatar: ./magali-de-labareyre.jpg

--- a/src/content/people/marie-douet/index.mdx
+++ b/src/content/people/marie-douet/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Marie Douet
 avatar: ./marie-douet.jpeg
 job: Web Developer

--- a/src/content/people/marie-douet/index.mdx
+++ b/src/content/people/marie-douet/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Marie Douet
 avatar: ./marie-douet.jpeg
 job: Web Developer

--- a/src/content/people/marwen-essalah/index.mdx
+++ b/src/content/people/marwen-essalah/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Marwen Essalah
 avatar: ./marwen.jpg
 country: tunisia

--- a/src/content/people/marwen-essalah/index.mdx
+++ b/src/content/people/marwen-essalah/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Marwen Essalah
 avatar: ./marwen.jpg
 country: tunisia

--- a/src/content/people/mathias-arlaud/index.mdx
+++ b/src/content/people/mathias-arlaud/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Mathias Arlaud
 avatar: ./mathias-arlaud.jpg
 country: france

--- a/src/content/people/mathias-arlaud/index.mdx
+++ b/src/content/people/mathias-arlaud/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Mathias Arlaud
 avatar: ./mathias-arlaud.jpg
 country: france

--- a/src/content/people/matt-l/index.mdx
+++ b/src/content/people/matt-l/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Matt L.
 avatar: ./matt-l.jpg
 job: Leading analyst, trainer and consultant

--- a/src/content/people/matt-l/index.mdx
+++ b/src/content/people/matt-l/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Matt L.
 avatar: ./matt-l.jpg
 job: Leading analyst, trainer and consultant

--- a/src/content/people/matthieu-bessat/index.mdx
+++ b/src/content/people/matthieu-bessat/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: french
 name: Matthieu Bessat
 avatar: ./matthieu-bessat.jpg
 job: Développeur back-end

--- a/src/content/people/matthieu-bessat/index.mdx
+++ b/src/content/people/matthieu-bessat/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: french
+bioLang: french
 name: Matthieu Bessat
 avatar: ./matthieu-bessat.jpg
 job: Développeur back-end

--- a/src/content/people/matthieu-coulon/index.mdx
+++ b/src/content/people/matthieu-coulon/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: french
 name: Matthieu Coulon
 avatar: ./matthieu-coulon.jpg
 job: Lead Dev Front End

--- a/src/content/people/matthieu-coulon/index.mdx
+++ b/src/content/people/matthieu-coulon/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: french
+bioLang: french
 name: Matthieu Coulon
 avatar: ./matthieu-coulon.jpg
 job: Lead Dev Front End

--- a/src/content/people/matthieu-mertens/index.mdx
+++ b/src/content/people/matthieu-mertens/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Matthieu Mertens
 avatar: ./matthieu-mertens.jpeg
 job: Product Lead

--- a/src/content/people/matthieu-mertens/index.mdx
+++ b/src/content/people/matthieu-mertens/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Matthieu Mertens
 avatar: ./matthieu-mertens.jpeg
 job: Product Lead

--- a/src/content/people/michel-boretti/index.mdx
+++ b/src/content/people/michel-boretti/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Michel Boretti
 avatar: ./michel-boretti.jpg
 job: Founder

--- a/src/content/people/michel-boretti/index.mdx
+++ b/src/content/people/michel-boretti/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Michel Boretti
 avatar: ./michel-boretti.jpg
 job: Founder

--- a/src/content/people/mohamed-ali-dridi/index.mdx
+++ b/src/content/people/mohamed-ali-dridi/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Mohamed Ali Dridi
 avatar: ./mohamed-ali-dridi.jpg
 job: CEO and Engineer

--- a/src/content/people/mohamed-ali-dridi/index.mdx
+++ b/src/content/people/mohamed-ali-dridi/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Mohamed Ali Dridi
 avatar: ./mohamed-ali-dridi.jpg
 job: CEO and Engineer

--- a/src/content/people/mohamed-rejeb/index.mdx
+++ b/src/content/people/mohamed-rejeb/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Mohamed Rejeb
 avatar: ./mohamed-rejeb.jpg
 job: Kotlin tech lead

--- a/src/content/people/mohamed-rejeb/index.mdx
+++ b/src/content/people/mohamed-rejeb/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Mohamed Rejeb
 avatar: ./mohamed-rejeb.jpg
 job: Kotlin tech lead

--- a/src/content/people/nabli-mohamed/index.mdx
+++ b/src/content/people/nabli-mohamed/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Spoot
 avatar: ./nabli-mohamed.jpg
 job: Video Game developer

--- a/src/content/people/nabli-mohamed/index.mdx
+++ b/src/content/people/nabli-mohamed/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Spoot
 avatar: ./nabli-mohamed.jpg
 job: Video Game developer

--- a/src/content/people/nhung-duong/index.mdx
+++ b/src/content/people/nhung-duong/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Nhung Duong
 avatar: ./nhung.jpg
 job: Project Manager Business Developer

--- a/src/content/people/nhung-duong/index.mdx
+++ b/src/content/people/nhung-duong/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Nhung Duong
 avatar: ./nhung.jpg
 job: Project Manager Business Developer

--- a/src/content/people/nicolas-dubien/index.mdx
+++ b/src/content/people/nicolas-dubien/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Nicolas Dubien
 avatar: ./nicolas-dubien.jpg
 job: Software Engineer

--- a/src/content/people/nicolas-dubien/index.mdx
+++ b/src/content/people/nicolas-dubien/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Nicolas Dubien
 avatar: ./nicolas-dubien.jpg
 job: Software Engineer

--- a/src/content/people/nicolas-grekas/index.mdx
+++ b/src/content/people/nicolas-grekas/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Nicolas Grekas
 avatar: ./nicolas-grekas.jpg
 job: Symfony Core Team

--- a/src/content/people/nicolas-grekas/index.mdx
+++ b/src/content/people/nicolas-grekas/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Nicolas Grekas
 avatar: ./nicolas-grekas.jpg
 job: Symfony Core Team

--- a/src/content/people/nicolas-torion/index.mdx
+++ b/src/content/people/nicolas-torion/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Nicolas Torion
 avatar: ./nicolas-torion.jpg
 job: Full-Stack Developer

--- a/src/content/people/nicolas-torion/index.mdx
+++ b/src/content/people/nicolas-torion/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Nicolas Torion
 avatar: ./nicolas-torion.jpg
 job: Full-Stack Developer

--- a/src/content/people/noe-tatoud/index.mdx
+++ b/src/content/people/noe-tatoud/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Noé Tatoud
 avatar: ./noe-tatoud.jpg
 job: Frontend Developer

--- a/src/content/people/noe-tatoud/index.mdx
+++ b/src/content/people/noe-tatoud/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Noé Tatoud
 avatar: ./noe-tatoud.jpg
 job: Frontend Developer

--- a/src/content/people/noratikah-zahidi/index.mdx
+++ b/src/content/people/noratikah-zahidi/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Noratikah Zahidi
 avatar: ./noratikah-zahidi.jpg
 ---

--- a/src/content/people/noratikah-zahidi/index.mdx
+++ b/src/content/people/noratikah-zahidi/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Noratikah Zahidi
 avatar: ./noratikah-zahidi.jpg
 ---

--- a/src/content/people/olivier-huber/index.mdx
+++ b/src/content/people/olivier-huber/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: french
+bioLang: french
 name: Olivier Huber
 avatar: ./olivier-huber.jpg
 job: Partner Solution Architect

--- a/src/content/people/olivier-huber/index.mdx
+++ b/src/content/people/olivier-huber/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: french
 name: Olivier Huber
 avatar: ./olivier-huber.jpg
 job: Partner Solution Architect

--- a/src/content/people/olivier-leplus/index.mdx
+++ b/src/content/people/olivier-leplus/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Olivier Leplus
 avatar: ./olivier-leplus.jpg
 job: Developer Advocate

--- a/src/content/people/olivier-leplus/index.mdx
+++ b/src/content/people/olivier-leplus/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Olivier Leplus
 avatar: ./olivier-leplus.jpg
 job: Developer Advocate

--- a/src/content/people/omar-borji/index.mdx
+++ b/src/content/people/omar-borji/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Omar Borji
 avatar: ./omar-borji.jpg
 job: Front-end and mobile developer

--- a/src/content/people/omar-borji/index.mdx
+++ b/src/content/people/omar-borji/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Omar Borji
 avatar: ./omar-borji.jpg
 job: Front-end and mobile developer

--- a/src/content/people/patrick-kaspercyzk/index.mdx
+++ b/src/content/people/patrick-kaspercyzk/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Patrick Kasperczyk
 avatar: ./cover.jpg
 job: Previously datacenter/DevOps

--- a/src/content/people/patrick-kaspercyzk/index.mdx
+++ b/src/content/people/patrick-kaspercyzk/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Patrick Kasperczyk
 avatar: ./cover.jpg
 job: Previously datacenter/DevOps

--- a/src/content/people/quentin-lerebours/index.mdx
+++ b/src/content/people/quentin-lerebours/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Quentin Lerebours
 avatar: ./quentin-lerebours.jpeg
 job: Project Manager & Developer

--- a/src/content/people/quentin-lerebours/index.mdx
+++ b/src/content/people/quentin-lerebours/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Quentin Lerebours
 avatar: ./quentin-lerebours.jpeg
 job: Project Manager & Developer

--- a/src/content/people/quy-nguyen/index.mdx
+++ b/src/content/people/quy-nguyen/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Quy Nguyen
 avatar: ./quy-nguyen.jpg
 country: vietnam

--- a/src/content/people/quy-nguyen/index.mdx
+++ b/src/content/people/quy-nguyen/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Quy Nguyen
 avatar: ./quy-nguyen.jpg
 country: vietnam

--- a/src/content/people/raihan-nismara/index.mdx
+++ b/src/content/people/raihan-nismara/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Raihan Nismara
 avatar: ./raihan-nismara.png
 job:  Frontend Engineer

--- a/src/content/people/raihan-nismara/index.mdx
+++ b/src/content/people/raihan-nismara/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Raihan Nismara
 avatar: ./raihan-nismara.png
 job:  Frontend Engineer

--- a/src/content/people/renan-decamps/index.mdx
+++ b/src/content/people/renan-decamps/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Renan Decamps
 avatar: ./renan-decamps.jpg
 job: Front-End Developer

--- a/src/content/people/renan-decamps/index.mdx
+++ b/src/content/people/renan-decamps/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Renan Decamps
 avatar: ./renan-decamps.jpg
 job: Front-End Developer

--- a/src/content/people/robin-chalas/index.mdx
+++ b/src/content/people/robin-chalas/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Robin Chalas
 avatar: ./robin-chalas.jpg
 country: france

--- a/src/content/people/robin-chalas/index.mdx
+++ b/src/content/people/robin-chalas/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Robin Chalas
 avatar: ./robin-chalas.jpg
 country: france

--- a/src/content/people/roch-dardie/index.mdx
+++ b/src/content/people/roch-dardie/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Roch Dardié
 avatar: ./roch-dardie.jpg
 job: Tech Leader

--- a/src/content/people/roch-dardie/index.mdx
+++ b/src/content/people/roch-dardie/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Roch Dardié
 avatar: ./roch-dardie.jpg
 job: Tech Leader

--- a/src/content/people/rudy-baer/index.mdx
+++ b/src/content/people/rudy-baer/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Rudy Baer
 avatar: ./rudy.jpg
 job: Founder & CTO

--- a/src/content/people/rudy-baer/index.mdx
+++ b/src/content/people/rudy-baer/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Rudy Baer
 avatar: ./rudy.jpg
 job: Founder & CTO

--- a/src/content/people/sami-belhadj/index.mdx
+++ b/src/content/people/sami-belhadj/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Sami Belhadj
 avatar: ./sami-belhadj.jpg
 job: Software Delivery Manager

--- a/src/content/people/sami-belhadj/index.mdx
+++ b/src/content/people/sami-belhadj/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Sami Belhadj
 avatar: ./sami-belhadj.jpg
 job: Software Delivery Manager

--- a/src/content/people/sang-tran-quoc/index.mdx
+++ b/src/content/people/sang-tran-quoc/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Sang Tran Quoc
 avatar: ./sang-tran-quoc.jpg
 country: vietnam

--- a/src/content/people/sang-tran-quoc/index.mdx
+++ b/src/content/people/sang-tran-quoc/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Sang Tran Quoc
 avatar: ./sang-tran-quoc.jpg
 country: vietnam

--- a/src/content/people/sebastien-ferrer/index.mdx
+++ b/src/content/people/sebastien-ferrer/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: french
 name: Sébastien Ferrer
 job: Software engineer in the cybersecurity team
 avatar: ./sebastien-ferrer.jpg

--- a/src/content/people/sebastien-ferrer/index.mdx
+++ b/src/content/people/sebastien-ferrer/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: french
+bioLang: french
 name: Sébastien Ferrer
 job: Software engineer in the cybersecurity team
 avatar: ./sebastien-ferrer.jpg

--- a/src/content/people/sofiane-boukhris/index.mdx
+++ b/src/content/people/sofiane-boukhris/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Sofiane Boukhris
 avatar: ./sofiane-boukhris.jpg
 job: Chief Product and Technology Officer

--- a/src/content/people/sofiane-boukhris/index.mdx
+++ b/src/content/people/sofiane-boukhris/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Sofiane Boukhris
 avatar: ./sofiane-boukhris.jpg
 job: Chief Product and Technology Officer

--- a/src/content/people/sonyth-huber/index.mdx
+++ b/src/content/people/sonyth-huber/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: french
+bioLang: french
 name: Sonyth HUBER
 avatar: ./sonyth-huber.jpg
 company:

--- a/src/content/people/sonyth-huber/index.mdx
+++ b/src/content/people/sonyth-huber/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: french
 name: Sonyth HUBER
 avatar: ./sonyth-huber.jpg
 company:

--- a/src/content/people/soraya-benchakroune/index.mdx
+++ b/src/content/people/soraya-benchakroune/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Soraya Benchakroune
 avatar: ./soraya-benchakroune.jpg
 job: Full-Stack Assistant

--- a/src/content/people/soraya-benchakroune/index.mdx
+++ b/src/content/people/soraya-benchakroune/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Soraya Benchakroune
 avatar: ./soraya-benchakroune.jpg
 job: Full-Stack Assistant

--- a/src/content/people/souhir-mkaouar/index.mdx
+++ b/src/content/people/souhir-mkaouar/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: french
+bioLang: french
 name: Souhir Mkaouar
 avatar: ./souhir-mkaouar.jpg
 country: tunisia

--- a/src/content/people/souhir-mkaouar/index.mdx
+++ b/src/content/people/souhir-mkaouar/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: french
 name: Souhir Mkaouar
 avatar: ./souhir-mkaouar.jpg
 country: tunisia

--- a/src/content/people/striebig-nicolas/index.mdx
+++ b/src/content/people/striebig-nicolas/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Nicolas Striebig
 avatar: ./striebig-nicolas.jpeg
 job: Chief Services Officer & Co-founder

--- a/src/content/people/striebig-nicolas/index.mdx
+++ b/src/content/people/striebig-nicolas/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Nicolas Striebig
 avatar: ./striebig-nicolas.jpeg
 job: Chief Services Officer & Co-founder

--- a/src/content/people/sylvain-dorey/index.mdx
+++ b/src/content/people/sylvain-dorey/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Sylvain Dorey
 avatar: ./sylvain-dorey.jpg
 job: Independent software engineer and data scientist

--- a/src/content/people/sylvain-dorey/index.mdx
+++ b/src/content/people/sylvain-dorey/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Sylvain Dorey
 avatar: ./sylvain-dorey.jpg
 job: Independent software engineer and data scientist

--- a/src/content/people/tanguy-rambaud/index.mdx
+++ b/src/content/people/tanguy-rambaud/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Tanguy Rambaud
 job: Co-founder & CEO
 avatar: ./tanguy-rambaud.jpg

--- a/src/content/people/tanguy-rambaud/index.mdx
+++ b/src/content/people/tanguy-rambaud/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Tanguy Rambaud
 job: Co-founder & CEO
 avatar: ./tanguy-rambaud.jpg

--- a/src/content/people/tiffany-souterre/index.mdx
+++ b/src/content/people/tiffany-souterre/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Tiffany Souterre
 avatar: ./tiffany-souterre.jpg
 job: Senior Developer Advocate

--- a/src/content/people/tiffany-souterre/index.mdx
+++ b/src/content/people/tiffany-souterre/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Tiffany Souterre
 avatar: ./tiffany-souterre.jpg
 job: Senior Developer Advocate

--- a/src/content/people/tony-godin/index.mdx
+++ b/src/content/people/tony-godin/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: french
+bioLang: french
 name: Tony Godin
 avatar: ./tony-godin.jpg
 job: Freelance

--- a/src/content/people/tony-godin/index.mdx
+++ b/src/content/people/tony-godin/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: french
 name: Tony Godin
 avatar: ./tony-godin.jpg
 job: Freelance

--- a/src/content/people/vianney-charpentier/index.mdx
+++ b/src/content/people/vianney-charpentier/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Vianney Charpentier
 avatar: ./vianney-charpentier.jpg
 job: Backend developer

--- a/src/content/people/vianney-charpentier/index.mdx
+++ b/src/content/people/vianney-charpentier/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Vianney Charpentier
 avatar: ./vianney-charpentier.jpg
 job: Backend developer

--- a/src/content/people/vin-lim/index.mdx
+++ b/src/content/people/vin-lim/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Vin Lim
 avatar: ./vin-lim.jpg
 country: malaysia

--- a/src/content/people/vin-lim/index.mdx
+++ b/src/content/people/vin-lim/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Vin Lim
 avatar: ./vin-lim.jpg
 country: malaysia

--- a/src/content/people/vu-thai-duong/index.mdx
+++ b/src/content/people/vu-thai-duong/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Vu Thai Duong
 avatar: ./vu-thai-duong.jpeg
 job: Delivery Manager

--- a/src/content/people/vu-thai-duong/index.mdx
+++ b/src/content/people/vu-thai-duong/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Vu Thai Duong
 avatar: ./vu-thai-duong.jpeg
 job: Delivery Manager

--- a/src/content/people/vu-tuan-anh/index.mdx
+++ b/src/content/people/vu-tuan-anh/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Tuan Anh Vu
 job: Project Manager, PM & Agile Trainer
 avatar: ./vu-tuan-anh.jpeg

--- a/src/content/people/vu-tuan-anh/index.mdx
+++ b/src/content/people/vu-tuan-anh/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Tuan Anh Vu
 job: Project Manager, PM & Agile Trainer
 avatar: ./vu-tuan-anh.jpeg

--- a/src/content/people/wang-haokai/index.mdx
+++ b/src/content/people/wang-haokai/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Wang Haokai
 avatar: ./wang-haokai.jpg
 job: Founder Zinc

--- a/src/content/people/wang-haokai/index.mdx
+++ b/src/content/people/wang-haokai/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Wang Haokai
 avatar: ./wang-haokai.jpg
 job: Founder Zinc

--- a/src/content/people/xavier-van-de-woestyne/index.mdx
+++ b/src/content/people/xavier-van-de-woestyne/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: french
 name: Xavier Van de Woestyne
 avatar: ./xavier-van-de-woestyne.jpg
 job: Web developer

--- a/src/content/people/xavier-van-de-woestyne/index.mdx
+++ b/src/content/people/xavier-van-de-woestyne/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: french
+bioLang: french
 name: Xavier Van de Woestyne
 avatar: ./xavier-van-de-woestyne.jpg
 job: Web developer

--- a/src/content/people/yann-jacquot/index.mdx
+++ b/src/content/people/yann-jacquot/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Yann Jacquot
 avatar: ./yann-jacquot.jpg
 job: Senior Architect and Coach

--- a/src/content/people/yann-jacquot/index.mdx
+++ b/src/content/people/yann-jacquot/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Yann Jacquot
 avatar: ./yann-jacquot.jpg
 job: Senior Architect and Coach

--- a/src/content/people/yasser-foudhil/index.mdx
+++ b/src/content/people/yasser-foudhil/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: french
 name: Yasser Foudhil
 avatar: ./yasser-foudhil.jpg
 job: Delivery Manager

--- a/src/content/people/yasser-foudhil/index.mdx
+++ b/src/content/people/yasser-foudhil/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: french
+bioLang: french
 name: Yasser Foudhil
 avatar: ./yasser-foudhil.jpg
 job: Delivery Manager

--- a/src/content/people/yassine-benabbas/index.mdx
+++ b/src/content/people/yassine-benabbas/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: french
 name: Yassine Benabbas
 avatar: ./yassine-benabbas.jpg
 job: PhD, teacher, and Software Development Community Advocate

--- a/src/content/people/yassine-benabbas/index.mdx
+++ b/src/content/people/yassine-benabbas/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: french
+bioLang: french
 name: Yassine Benabbas
 avatar: ./yassine-benabbas.jpg
 job: PhD, teacher, and Software Development Community Advocate

--- a/src/content/people/yoann-fleury/index.mdx
+++ b/src/content/people/yoann-fleury/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Yoann Fleury
 avatar: ./yoann-fleury.png
 job: Lead Front-End

--- a/src/content/people/yoann-fleury/index.mdx
+++ b/src/content/people/yoann-fleury/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Yoann Fleury
 avatar: ./yoann-fleury.png
 job: Lead Front-End

--- a/src/content/people/yoann-ono-dit-biot/index.mdx
+++ b/src/content/people/yoann-ono-dit-biot/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Yoann Ono Dit Biot
 job : RED Leader - Consultant cybersécurité
 company:

--- a/src/content/people/yoann-ono-dit-biot/index.mdx
+++ b/src/content/people/yoann-ono-dit-biot/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Yoann Ono Dit Biot
 job : RED Leader - Consultant cybersécurité
 company:

--- a/src/content/people/zouhair-mkassmi/index.mdx
+++ b/src/content/people/zouhair-mkassmi/index.mdx
@@ -1,5 +1,5 @@
 ---
-lang: english
+bioLang: english
 name: Zouhair Mkassmi
 avatar: zouhair.png
 job: Backend developper

--- a/src/content/people/zouhair-mkassmi/index.mdx
+++ b/src/content/people/zouhair-mkassmi/index.mdx
@@ -1,4 +1,5 @@
 ---
+lang: english
 name: Zouhair Mkassmi
 avatar: zouhair.png
 job: Backend developper

--- a/src/pages/people/[id]/index.astro
+++ b/src/pages/people/[id]/index.astro
@@ -12,6 +12,7 @@ import ContributionCard from "@/components/ContributionCard/index.astro";
 import { render } from "astro:content";
 import { SOCIALS_TYPE_MAP } from "@/content/socials";
 import Prose from "@/components/Prose/index.astro";
+import { lang } from "@/lib/lang";
 import JoinTheCommunity from "@/components/JoinTheCommunity/index.astro";
 import TiltedCard from "@/components/TiltedCard";
 import { BackButton } from "@/components/BackButton";
@@ -151,7 +152,7 @@ const personAchievements = getPersonAchievements(person);
                 <h2 class="w-full font-heading text-xl uppercase tracking-wider">
                   About {person.data.name}
                 </h2>
-                <Prose class="prose-sm">
+                <Prose class="prose-sm" lang={lang(person.data.lang)}>
                   <Content />
                 </Prose>
               </div>

--- a/src/pages/people/[id]/index.astro
+++ b/src/pages/people/[id]/index.astro
@@ -152,7 +152,7 @@ const personAchievements = getPersonAchievements(person);
                 <h2 class="w-full font-heading text-xl uppercase tracking-wider">
                   About {person.data.name}
                 </h2>
-                <Prose class="prose-sm" lang={lang(person.data.lang)}>
+                <Prose class="prose-sm" lang={lang(person.data.bioLang)}>
                   <Content />
                 </Prose>
               </div>

--- a/src/schemas/people.ts
+++ b/src/schemas/people.ts
@@ -1,3 +1,4 @@
+import { zLanguage } from "@/schemas/language";
 import { zSocialTypes } from "@/schemas/utils";
 import { z } from "astro/zod";
 import { reference, type SchemaContext } from "astro:content";
@@ -6,6 +7,7 @@ export type Person = z.infer<ReturnType<typeof zPerson>>;
 export const zPerson = ({ image }: SchemaContext) =>
   z.object({
     name: z.string(),
+    lang: zLanguage(),
     avatar: image().optional(),
     job: z.string().optional(),
     socials: z

--- a/src/schemas/people.ts
+++ b/src/schemas/people.ts
@@ -7,7 +7,7 @@ export type Person = z.infer<ReturnType<typeof zPerson>>;
 export const zPerson = ({ image }: SchemaContext) =>
   z.object({
     name: z.string(),
-    lang: zLanguage(),
+    bioLang: zLanguage(),
     avatar: image().optional(),
     job: z.string().optional(),
     socials: z


### PR DESCRIPTION
Add a `lang` field (using the existing language enum) to the person schema, making it required. This allows setting the HTML `lang` attribute on bio blocks so browsers and screen readers handle French/English content correctly. All 104 people entries are updated.