### PR TITLE
feat: make contentLanguage mandatory in talk schema

### DIFF
--- a/src/content/talks/3d-animation-and-design.mdx
+++ b/src/content/talks/3d-animation-and-design.mdx
@@ -3,6 +3,7 @@ title: "3D, animation and design"
 speakers:
   - id: ahmed-ben-jbara
 language: english
+contentLanguage: english
 ---
 
 A talk exploring the world of 3D, animation, and computer-generated visual design. Attendees will gain insight into what 3D is, its diverse applications,

--- a/src/content/talks/advanced-unit-testing-for-web-accessibility.mdx
+++ b/src/content/talks/advanced-unit-testing-for-web-accessibility.mdx
@@ -3,6 +3,7 @@ title: "Advanced Unit Testing For Web Accessibility"
 speakers:
   - id: raihan-nismara 
 language: english
+contentLanguage: english
 vod:
   type: "youtube"
   youtubeId: "6Qt-Q4troLE"

--- a/src/content/talks/ai-and-software-engineering-transformation-not-replacement.mdx
+++ b/src/content/talks/ai-and-software-engineering-transformation-not-replacement.mdx
@@ -3,6 +3,7 @@ title: "AI and Software Engineering: Transformation, Not Replacement"
 speakers:
   - id: geert-theys
 language: english
+contentLanguage: english
 ---
 
 AI is changing the role of software engineers. Instead of replacing us, AI is pushing engineers to focus more on higher-level tasks like system architecture

--- a/src/content/talks/behind-the-screens-hacker-tactics-to-steal-your-data.mdx
+++ b/src/content/talks/behind-the-screens-hacker-tactics-to-steal-your-data.mdx
@@ -3,6 +3,7 @@ title: "Behind the Screens: Hacker Tactics to Steal Your Data"
 speakers:
   - id: striebig-nicolas
 language: english
+contentLanguage: english
 ---
 
 Step into the intriguing world of hackers and uncover the techniques they use to access personal and sensitive information. Explore their methods, understand the risks and learn how to protect yourself in today’s digital landscape.

--- a/src/content/talks/bridging-compiling-and-rendering-how-cross-platform-frameworks-work.mdx
+++ b/src/content/talks/bridging-compiling-and-rendering-how-cross-platform-frameworks-work.mdx
@@ -3,6 +3,7 @@ title: "Bridging, Compiling, and Rendering: How Cross-Platform Frameworks Work"
 speakers:
   - id: mohamed-rejeb
 language: english
+contentLanguage: english
 vod:
   type: "youtube"
   youtubeId: "agiwwDeURmQ"

--- a/src/content/talks/building-a-web3-startup-in-malaysia.mdx
+++ b/src/content/talks/building-a-web3-startup-in-malaysia.mdx
@@ -3,6 +3,7 @@ title: "Building a Web3 Startup in Malaysia"
 speakers:
   - id: eason-chai
 language: english
+contentLanguage: english
 feedback:
   link: https://openfeedback.io/forkit-kl-2025/2025-10-25/d1I1CrS023VXD57G3pOP
 vod:

--- a/src/content/talks/building-an-ai-company-creating-real-value-from-uncertain-technology.mdx
+++ b/src/content/talks/building-an-ai-company-creating-real-value-from-uncertain-technology.mdx
@@ -3,6 +3,7 @@ title: "Building an AI Company: Creating Real Value from Uncertain Technology"
 speakers:
   - id: wang-haokai
 language: english
+contentLanguage: english
 ---
 
 Large Language Models (LLMs) are transforming how we build software, but their real business value is still unclear to many teams. In this talk, I'll share our experience building an AI company on top of this fast-evolving technology — including lessons learned, mistakes made, and what actually worked.

--- a/src/content/talks/building-and-deploying-a-model-in-the-browser-to-do-gesture-recognition.mdx
+++ b/src/content/talks/building-and-deploying-a-model-in-the-browser-to-do-gesture-recognition.mdx
@@ -3,6 +3,7 @@ title: "Building and deploying a model in the browser to do gesture recognition"
 speakers:
   - id: gabriel-pichot
 language: english
+contentLanguage: english
 ---
 
 This talk demonstrates how to implement live gesture recognition in browsers

--- a/src/content/talks/ce-que-tout-developpeur-spring-doit-savoir-pieges-courants-et-techniques-defficacite.mdx
+++ b/src/content/talks/ce-que-tout-developpeur-spring-doit-savoir-pieges-courants-et-techniques-defficacite.mdx
@@ -3,6 +3,7 @@ title: "Ce que tout développeur Spring doit savoir : Pièges courants et techni
 speakers:
   - id: atef-maddouri
 language: french
+contentLanguage: french
 vod:
   type: "youtube"
   youtubeId: "biY-QOfNYDU"

--- a/src/content/talks/codons-un-maitre-du-jeu-de-role-multi-agents-avec-strands-agents.mdx
+++ b/src/content/talks/codons-un-maitre-du-jeu-de-role-multi-agents-avec-strands-agents.mdx
@@ -4,6 +4,7 @@ speakers:
   - id: olivier-leplus
   - id: tiffany-souterre
 language: french
+contentLanguage: french
 ---
 
 Le maitre du jeu (MJ) joue un role central dans les jeux de role: il cree les histoires des joueurs, incarne les PNJ et s'assure que les regles soient respectees. L'IA peut etre un formidable allie pour les MJ, en les aidant a verifier les regles, improviser des scenarios et creer du contenu a la volee. Dans ce talk/live coding, nous coderons ensemble un maitre du jeu IA multi-agents a l'aide du SDK open source Strands Agents. Nous mettrons en place des agents specialises pour differentes responsabilites du MJ et verrons comment ils collaborent via le protocole Agent-to-Agent (A2A) et des integrations d'outils grace au protocole MCP.

--- a/src/content/talks/corporate-security-leverage-osint-corporate-intelligence-cyber-resilience-for-proactive-governance.mdx
+++ b/src/content/talks/corporate-security-leverage-osint-corporate-intelligence-cyber-resilience-for-proactive-governance.mdx
@@ -3,6 +3,7 @@ title: "CORPORATE SECURITY : leverage OSINT, corporate intelligence, cyber resil
 speakers:
   - id: matt-l
 language: english
+contentLanguage: english
 ---
 
 As digital transformation accelerates, organizations must evolve from reactive risk management to intelligence-driven foresight.

--- a/src/content/talks/creation-et-release-via-gitlab-ci-d-une-librairie-java-multi-profils.mdx
+++ b/src/content/talks/creation-et-release-via-gitlab-ci-d-une-librairie-java-multi-profils.mdx
@@ -3,6 +3,7 @@ title: "Creating and Releasing a Multi-Profile Java Library via GitLab CI: A How
 speakers:
   - id: zouhair-mkassmi
 language: french
+contentLanguage: french
 ---
 
 In more and more projects, we find ourselves needing libraries to share code and features, all while managing different framework versions. At CamelStudio, we encountered this need in one of our projects: developing a Java library compatible with both Java 17 and Java 8. 

--- a/src/content/talks/decouvrons-ensemble-la-releve-de-lobservabilite-avec-les-logs-et-traces-quickwit.mdx
+++ b/src/content/talks/decouvrons-ensemble-la-releve-de-lobservabilite-avec-les-logs-et-traces-quickwit.mdx
@@ -3,6 +3,7 @@ title: "Let's discover together the next generation of observability with logs a
 speakers:
   - id: idriss-neumann
 language: english
+contentLanguage: english
 vod:
   type: "youtube"
   youtubeId: "6IzjjPUQQ4E"

--- a/src/content/talks/deploy-anything-with-ai-from-elixir-to-rust-to-edge-functions.mdx
+++ b/src/content/talks/deploy-anything-with-ai-from-elixir-to-rust-to-edge-functions.mdx
@@ -3,6 +3,7 @@ title: "Deploy Anything with AI: From Elixir to Rust to Edge Functions"
 speakers:
   - id: erwan-rougeux
 language: english
+contentLanguage: english
 ---
 
 What if AI could become your DevOps pair? In this session, we'll show how to build an AI-assisted deployment pipeline that understands your code

--- a/src/content/talks/designing-with-llms-rethinking-code-functionality-and-user-interfaces.mdx
+++ b/src/content/talks/designing-with-llms-rethinking-code-functionality-and-user-interfaces.mdx
@@ -3,6 +3,7 @@ title: "Designing with LLMs: Rethinking code, functionality, and user interfaces
 speakers:
   - id: sylvain-dorey
 language: english
+contentLanguage: english
 feedback:
   link: https://openfeedback.io/forkit-kl-2025/2025-10-25/6XERHY2ml8pmYGBeiMoe
 vod:

--- a/src/content/talks/digital-sovereignty-and-ai-the-strategic-cost-of-inaction.mdx
+++ b/src/content/talks/digital-sovereignty-and-ai-the-strategic-cost-of-inaction.mdx
@@ -3,6 +3,7 @@ title: "Digital Sovereignty & AI: The Strategic Cost of Inaction"
 speakers:
   - id: erwan-rougeux
 language: english
+contentLanguage: english
 ---
 
 In a world shaped by accelerating geopolitical tensions and exponential AI adoption, digital infrastructure is no longer a technical choice — it is a strategic one.

--- a/src/content/talks/eco-conception-contraintes-ou-opportunites.mdx
+++ b/src/content/talks/eco-conception-contraintes-ou-opportunites.mdx
@@ -8,6 +8,7 @@ speakers:
   - id: tony-godin
     role: Roundtable host
 language: french
+contentLanguage: french
 ---
 
 Let's discuss the subject that comes up in every tech brief. Real new approach

--- a/src/content/talks/embarquer-votre-modele-de-machine-learning-dans-votre-app.mdx
+++ b/src/content/talks/embarquer-votre-modele-de-machine-learning-dans-votre-app.mdx
@@ -3,6 +3,7 @@ title: "Embarquer votre modèle de machine learning dans votre app ?"
 speakers:
   - id: hugo-gresse
 language: french
+contentLanguage: french
 vod:
   type: youtube
   youtubeId: P8mpEdZ3R1Q

--- a/src/content/talks/first-big-project-keep-calm-adapt-and-learn.mdx
+++ b/src/content/talks/first-big-project-keep-calm-adapt-and-learn.mdx
@@ -3,6 +3,7 @@ title: "First big project? Keep calm, adapt and learn"
 speakers:
   - id: marie-douet
 language: english
+contentLanguage: english
 ---
 
 You thought you'd feel quickly comfortable in your first dev job… but what happens when the project is huge and already halfway done?

--- a/src/content/talks/from-black-box-to-white-box-generative-ai-evaluation-on-googles-vertex-ai.mdx
+++ b/src/content/talks/from-black-box-to-white-box-generative-ai-evaluation-on-googles-vertex-ai.mdx
@@ -3,6 +3,7 @@ title: "From Black-Box to White-Box: Generative AI Evaluation on Google's Vertex
 speakers:
   - id: eya-laouini
 language: english
+contentLanguage: english
 ---
 
 My session titled "From Black-Box to White-Box: Generative AI Evaluation on Google's Vertex AI", will provide attendees with a strategic framework to transition from subjective model testing to rigorous, data-driven evaluation using Vertex AI.

--- a/src/content/talks/from-project-to-product-rethinking-how-it-initiatives-should-be-funded.mdx
+++ b/src/content/talks/from-project-to-product-rethinking-how-it-initiatives-should-be-funded.mdx
@@ -3,6 +3,7 @@ title: "From project to product: rethinking how IT initiatives should be funded.
 speakers:
   - id: vu-tuan-anh
 language: english
+contentLanguage: english
 vod:
   type: youtube
   youtubeId: mJbd2oPwFQg

--- a/src/content/talks/from-vibe-coding-to-vibe-learning.mdx
+++ b/src/content/talks/from-vibe-coding-to-vibe-learning.mdx
@@ -3,6 +3,7 @@ title: "From Vibe Coding to Vibe Learning"
 speakers:
   - id: cedric-due
 language: english
+contentLanguage: english
 ---
 
 AI-powered coding tools have dramatically changed the way we write software. Today, generating large amounts of code is as simple as describing what we want. While _Vibe Coding_ can boost short-term productivity, it also introduces a serious risk: writing and deploying code we do not truly understand — a growing concern for many companies.

--- a/src/content/talks/from-zero-to-live-is-it-possible-to-ship-an-app-in-45-minutes.mdx
+++ b/src/content/talks/from-zero-to-live-is-it-possible-to-ship-an-app-in-45-minutes.mdx
@@ -3,6 +3,7 @@ title: "From Zero to Live: Is it possible to ship an app in 45 minutes?"
 speakers:
   - id: hugo-perard
 language: english
+contentLanguage: english
 feedback:
   link: https://openfeedback.io/forkit-kl-2025/2025-10-25/e6WOH6WDXT3fXlobqKHP
 vod:

--- a/src/content/talks/game-development.mdx
+++ b/src/content/talks/game-development.mdx
@@ -3,6 +3,7 @@ title: "How as a game developer, I had to be a marketer, doctor, manager and man
 speakers:
   - id: nabli-mohamed
 language: english
+contentLanguage: english
 vod:
   type: "youtube"
   youtubeId: "gb-CZ3g8qd8"

--- a/src/content/talks/generating-vegetation-in-real-time-from-grass-blade-to-giant-trees.mdx
+++ b/src/content/talks/generating-vegetation-in-real-time-from-grass-blade-to-giant-trees.mdx
@@ -3,6 +3,7 @@ title: "Generating vegetation in real-time from grass blade to giant trees. 20km
 speakers:
   - id: jean-baptiste-briant
 language: english
+contentLanguage: english
 ---
 I leveraged the best of all worlds to create a system of unmatched performance in Unreal Engine. It’s versatile, highly customizable, ultra fast and precise. It was a nightmare of 800 hours to code, the first time ever in my decade+ career that I doubted my capacity to just even conceive the software, not mentioning implementing the solution.
 

--- a/src/content/talks/giving-pixels-a-pulse-a-guide-to-audio-reactive-shaders.mdx
+++ b/src/content/talks/giving-pixels-a-pulse-a-guide-to-audio-reactive-shaders.mdx
@@ -3,6 +3,7 @@ title: "Giving Pixels a Pulse: A Guide to Audio-Reactive Shaders"
 speakers:
   - id: mohamed-rejeb
 language: english
+contentLanguage: english
 vod:
   type: "youtube"
   youtubeId: "kh70VtCB2zY"

--- a/src/content/talks/homelab-renaissance.mdx
+++ b/src/content/talks/homelab-renaissance.mdx
@@ -3,6 +3,7 @@ title: "Homelab Renaissance: 21 Stacks, 200 Services, Full Autonomy"
 speakers:
   - id: erwan-rougeux
 language: english
+contentLanguage: english
 vod:
   type: "youtube"
   youtubeId: "_3tZI-2GfrM"

--- a/src/content/talks/how-can-the-private-hospital-operating-model-inspire-tech-teams.mdx
+++ b/src/content/talks/how-can-the-private-hospital-operating-model-inspire-tech-teams.mdx
@@ -3,6 +3,7 @@ title: "How can the private hospital operating model inspire tech teams?"
 speakers:
   - id: matthieu-mertens
 language: english
+contentLanguage: english
 vod:
   type: youtube
   youtubeId: B59qdvITdro

--- a/src/content/talks/how-i-ported-doom-to-the-browser-with-webassembly.mdx
+++ b/src/content/talks/how-i-ported-doom-to-the-browser-with-webassembly.mdx
@@ -3,6 +3,7 @@ title: "How I Ported Doom to the Browser with WebAssembly"
 speakers:
   - id: yassine-benabbas
 language: english
+contentLanguage: english
 vod:
   type: "youtube"
   youtubeId: "j2GUkruqO0E"

--- a/src/content/talks/how-to-make-your-open-source-project-popular.mdx
+++ b/src/content/talks/how-to-make-your-open-source-project-popular.mdx
@@ -3,6 +3,7 @@ title: "How to Make Your Open Source Project Popular"
 speakers:
   - id: andrey-sitnik
 language: english
+contentLanguage: english
 feedback:
   link: https://openfeedback.io/fork-it-community-rouen-2024/2024-06-07/38GH3p4CustoJ5tAxFNi
 vod:

--- a/src/content/talks/how-to-use-ai-to-evolve-an-internal-react-library-adapting-to-workplace-realities.mdx
+++ b/src/content/talks/how-to-use-ai-to-evolve-an-internal-react-library-adapting-to-workplace-realities.mdx
@@ -3,6 +3,7 @@ title: "How to use AI to evolve an internal react library: Adapting to workplace
 speakers:
   - id: noe-tatoud
 language: english
+contentLanguage: english
 ---
 We frequently discuss highly optimized Design Systems, open-source UI kits, and sophisticated 
 libraries like shadcn/ui or Material UI.

--- a/src/content/talks/insane-fast-to-production-using-astro.mdx
+++ b/src/content/talks/insane-fast-to-production-using-astro.mdx
@@ -3,6 +3,7 @@ title: "Insane fast to production using Astro"
 speakers:
   - id: elian-van-cutsem
 language: english
+contentLanguage: english
 vod:
   type: "youtube"
   youtubeId: "zUZHI6UX8LE"

--- a/src/content/talks/invisible-work-in-project-delivery-why-youre-always-behind-schedule.mdx
+++ b/src/content/talks/invisible-work-in-project-delivery-why-youre-always-behind-schedule.mdx
@@ -3,6 +3,7 @@ title: "Invisible Work in Project Delivery - Why You're Always Behind Schedule"
 speakers:
   - id: vu-thai-duong
 language: english
+contentLanguage: english
 ---
 
 Ever felt like you're constantly behind schedule, even though you're coding all day?

--- a/src/content/talks/is-code-refactoring-scary.mdx
+++ b/src/content/talks/is-code-refactoring-scary.mdx
@@ -3,6 +3,7 @@ title: "Is Code Refactoring Scary ? "
 speakers:
   - id: houssem-balti
 language: english
+contentLanguage: english
 ---
 
 When trying to refactor code, how many times have you traveled back in time unraveling mysteries, revisiting forgotten decisions, and questioning past logic just to make sense of it all?

--- a/src/content/talks/keynote-olivier-and-sonyth.mdx
+++ b/src/content/talks/keynote-olivier-and-sonyth.mdx
@@ -4,6 +4,7 @@ speakers:
   - id: olivier-huber
   - id: sonyth-huber
 language: english
+contentLanguage: english
 vod:
   type: "youtube"
   youtubeId: "qyOP7OZrlJk"

--- a/src/content/talks/la-boite-a-outils-dun-uxui-designer-freelance-defis-et-solutions.mdx
+++ b/src/content/talks/la-boite-a-outils-dun-uxui-designer-freelance-defis-et-solutions.mdx
@@ -3,6 +3,7 @@ title: "La boite à outils d'un UX/UI Designer Freelance: Défis et solutions"
 speakers:
   - id: souhir-mkaouar
 language: french
+contentLanguage: french
 vod:
   type: "youtube"
   youtubeId: "Teg1EYngOm8"

--- a/src/content/talks/le-futur-de-lia-est-dans-les-navigateurs.mdx
+++ b/src/content/talks/le-futur-de-lia-est-dans-les-navigateurs.mdx
@@ -3,6 +3,7 @@ title: "Le futur de l'IA (est) dans les navigateurs"
 speakers:
   - id: yassine-benabbas
 language: french
+contentLanguage: french
 ---
 
 Avec l'essor de l'IA generative (GenAI), de plus en plus d'applications tirent parti de fonctionnalites liees a l'IA, comme la traduction automatique ou la transcription vocale. Cependant, on peut croire que leur mise en place necessite systematiquement un backend dedie, ce qui peut complexifier le developpement et la maintenance des applications. Ceci ne sera bientot plus le cas grace aux avancees recentes dans les navigateurs web.

--- a/src/content/talks/le-produit-entre-la-qualite-et-lover-engineering.mdx
+++ b/src/content/talks/le-produit-entre-la-qualite-et-lover-engineering.mdx
@@ -3,6 +3,7 @@ title: "Le produit entre la qualité et  l'Over-Engineering"
 speakers:
   - id: jihene-mejri
 language: french
+contentLanguage: french
 vod:
   type: "youtube"
   youtubeId: "_CaD7eWgtWg"

--- a/src/content/talks/le-systeme-distribue-qui-a-survecu-a-1-milliards-de-series.mdx
+++ b/src/content/talks/le-systeme-distribue-qui-a-survecu-a-1-milliards-de-series.mdx
@@ -3,6 +3,7 @@ title: "Le système distribué qui a survécu à 1 milliards de séries"
 speakers:
   - id: alexandre-burgoni
 language: french
+contentLanguage: french
 vod:
   type: youtube
   youtubeId: B9c1Koryfog

--- a/src/content/talks/les-listes-virtuelles-sauveront-ton-dom.mdx
+++ b/src/content/talks/les-listes-virtuelles-sauveront-ton-dom.mdx
@@ -3,6 +3,7 @@ title: "Les listes virtuelles sauveront ton dom"
 speakers:
   - id: matthieu-coulon
 language: french
+contentLanguage: french
 vod:
   type: "youtube"
   youtubeId: "9NFwEB4Zq4I"

--- a/src/content/talks/leveraging-the-expressionlanguage-component-let-your-users-be-creative.mdx
+++ b/src/content/talks/leveraging-the-expressionlanguage-component-let-your-users-be-creative.mdx
@@ -3,6 +3,7 @@ title: "Leveraging the ExpressionLanguage component. Let your users be creative!
 speakers:
   - id: mathias-arlaud
 language: english
+contentLanguage: english
 ---
 
 The ExpressionLanguage component is an old but very useful component. Many well known projects are using it (OroCRM, API Platform, Sylius, Symfony itself, ...).

--- a/src/content/talks/local-first-has-a-branding-problem.mdx
+++ b/src/content/talks/local-first-has-a-branding-problem.mdx
@@ -3,6 +3,7 @@ title: "Local-first Has a Branding Problem"
 speakers:
   - id: david-gomes
 language: english
+contentLanguage: english
 ---
 
 Is "React on the Server, Postgres on the Client" the new normal? Well, probably not for 99% of you. The truth is that local-first software development hasn't really caught on yet. And hearing about Linear and Figma as the de facto references is getting kind of old. Why haven't local-first architectures become more popular? I fundamentally believe that local-first has a branding problem. The term "local-first" itself drives many of us towards an instinctive repulse — "Oh no, not that fad again", or "Why would I even need local-first?".

--- a/src/content/talks/maintaining-an-open-source-library-for-Next-js-feedback-and-tips.mdx
+++ b/src/content/talks/maintaining-an-open-source-library-for-Next-js-feedback-and-tips.mdx
@@ -3,6 +3,7 @@ title: "Maintaining an open-source library for Next.js, feedback and tips"
 speakers:
   - id: francois-best
 language: english
+contentLanguage: english
 feedback:
   link: https://openfeedback.io/fork-it-community-rouen-2024/2024-06-07/1W8YqrpIZMyd0djfkc9U
 vod:

--- a/src/content/talks/mcp-4-data-quand-votre-ai-parle-a-votre-datalake.mdx
+++ b/src/content/talks/mcp-4-data-quand-votre-ai-parle-a-votre-datalake.mdx
@@ -3,6 +3,7 @@ title: "MCP 4 Data: quand votre AI parle à votre datalake"
 speakers:
   - id: roch-dardie
 language: french
+contentLanguage: french
 ---
 
 

--- a/src/content/talks/modern-stack-for-old-books-engineering-a-digital-library-for-southeast-asian-history.mdx
+++ b/src/content/talks/modern-stack-for-old-books-engineering-a-digital-library-for-southeast-asian-history.mdx
@@ -3,6 +3,7 @@ title: "Modern stack for old books: Engineering a digital library for Southeast 
 speakers:
   - id: sylvain-dorey
 language: english
+contentLanguage: english
 ---
 
 Spreading knowledge and facts in the current era of post-truth, short-form content and deep fakes is more important than ever. History and archives help us deal with the flood of sloppy and misleading information. But working with real archives comes with specific difficulties: large volumes of data, useful information hidden in noise, poor scan quality, handwritten texts that are hard to read.

--- a/src/content/talks/navigating-and-redesigning-payment-systems-for-global-connection.mdx
+++ b/src/content/talks/navigating-and-redesigning-payment-systems-for-global-connection.mdx
@@ -3,6 +3,7 @@ title: "Navigating and Redesigning Payment Systems for Global Connection"
 speakers:
   - id: adaku-nwakanma
 language: english
+contentLanguage: english
 ---
 
 Global payment systems are intended to connect us all, yet they often overlook the unique challenges faced by people in underserved economies. This talk dives into the creative ways Nigerians navigate and design payment solutions when major platforms fail to address local realities. For freelancers and entrepreneurs from Nigeria and other similar socioeconomic contexts, accessing international clients or services isn’t always straightforward. Traditional payment systems can be restrictive, making it difficult to send or receive funds, and global platforms often lack support for local currencies, banking structures, and reliable access.

--- a/src/content/talks/navigating-the-challenges-and-unlocking-the-potential-of-retrieval-augmented-generation.mdx
+++ b/src/content/talks/navigating-the-challenges-and-unlocking-the-potential-of-retrieval-augmented-generation.mdx
@@ -3,6 +3,7 @@ title: "Navigating the Challenges and Unlocking the Potential of Retrieval-Augme
 speakers:
   - id: luis-rubiera
 language: english
+contentLanguage: english
 ---
 
 One of the existing solution to avoid AI hallucinations and constant tunning, is RAG, but this is not magic, by bringing this tool we add some complex problems to a solution that was made to be simple to use.

--- a/src/content/talks/one-dissatisfied-customer-led-me-to-redesign-web-design.mdx
+++ b/src/content/talks/one-dissatisfied-customer-led-me-to-redesign-web-design.mdx
@@ -3,6 +3,7 @@ title: "One dissatisfied customer led me to redesign web design!"
 speakers:
   - id: michel-boretti
 language: english
+contentLanguage: english
 ---
 
 As web development started in the late 90s, monitors:

--- a/src/content/talks/open-infrastructure-for-ai-era.mdx
+++ b/src/content/talks/open-infrastructure-for-ai-era.mdx
@@ -3,6 +3,7 @@ title: "Open infrastructure for AI era"
 speakers:
   - id: sang-tran-quoc
 language: english
+contentLanguage: english
 ---
 
 This presentation introduces Open Infrastructure for the AI Era, highlighting how open-source technologies—led by OpenStack and the OpenInfra ecosystem—are emerging as a foundational platform for next-generation AI and HPC workloads. Drawing insights from the first OpenInfra for AI Working Group white paper, the talk explores reference architectures, best practices, and real-world use cases that demonstrate how open infrastructure can power AI training, inference, GPU-as-a-Service, MLOps platforms, high-performance computing clusters, and AI at the edge.

--- a/src/content/talks/openstreetmap-live-editing-workshop.mdx
+++ b/src/content/talks/openstreetmap-live-editing-workshop.mdx
@@ -5,4 +5,5 @@ speakers:
   - id: matthieu-bessat
   - id: hugo-kwiatkowski
 language: french
+contentLanguage: french
 ---

--- a/src/content/talks/react-native-ui-and-style-made-easy-and-fast-with-ficus-ui.mdx
+++ b/src/content/talks/react-native-ui-and-style-made-easy-and-fast-with-ficus-ui.mdx
@@ -3,6 +3,7 @@ title: "React Native UI and style made easy and fast with Ficus UI"
 speakers:
   - id: nicolas-torion
 language: english
+contentLanguage: english
 vod:
   type: youtube
   youtubeId: 5N7-J4oDxHI

--- a/src/content/talks/rebooting-engineering-from-ticket-takers-to-business-builders.mdx
+++ b/src/content/talks/rebooting-engineering-from-ticket-takers-to-business-builders.mdx
@@ -3,6 +3,7 @@ title: "Rebooting Engineering: From Ticket Takers to Business Builders"
 speakers:
   - id: erez-david-shtayman
 language: english
+contentLanguage: english
 feedback:
   link: https://openfeedback.io/forkit-kl-2025/2025-10-25/uCPyKicZb983GG3hsR3V
 ---

--- a/src/content/talks/reconfigurer-symfony-en-temps-reel-avec-des-sidekicks-applicatifs.mdx
+++ b/src/content/talks/reconfigurer-symfony-en-temps-reel-avec-des-sidekicks-applicatifs.mdx
@@ -3,6 +3,7 @@ title: "Reconfigurer Symfony en temps réel avec des sidekicks applicatifs"
 speakers:
   - id: nicolas-grekas
 language: french
+contentLanguage: french
 ---
 
 PHP a longtemps été pensé comme un langage strictement stateless : une requête, un processus, puis tout recommence.

--- a/src/content/talks/shaping-symfony-8-shipping-symfony-8-lessons-from-the-inside.mdx
+++ b/src/content/talks/shaping-symfony-8-shipping-symfony-8-lessons-from-the-inside.mdx
@@ -4,6 +4,7 @@ speakers:
   - id: mathias-arlaud
   - id: robin-chalas
 language: english
+contentLanguage: english
 ---
 
 Symfony 8 represents a major leap forward for the framework. As core team members, we've helped shape this evolution. As founders of baksla.sh, we've lived with the consequences of our architectural choices in production.

--- a/src/content/talks/shipping-ai-powered-react-native-apps.mdx
+++ b/src/content/talks/shipping-ai-powered-react-native-apps.mdx
@@ -3,6 +3,7 @@ title: "Shipping AI-Powered React Native Apps"
 speakers:
   - id: aziz-becha
 language: english
+contentLanguage: english
 ---
 
 This talk explores how to build and ship intelligent mobile experiences using both remote LLM providers and fully on-device models. We'll compare Remote, Hybrid, and Local architectures, break down their trade-offs across privacy, cost, and latency, and walk through practical integration patterns using APIs and React Native AI. You'll leave with clear mental models and production-ready strategies to confidently design, optimize, and scale AI features in real-world React Native apps.

--- a/src/content/talks/stop-chasing-everyone-focusing-on-your-1-percent-client-and-wins-the-market.mdx
+++ b/src/content/talks/stop-chasing-everyone-focusing-on-your-1-percent-client-and-wins-the-market.mdx
@@ -4,6 +4,7 @@ speakers:
   - id: hugo-siow
   - id: kelvin-lai
 language: english
+contentLanguage: english
 ---
 
 When people invite me to share, they usually expect me to talk about property deals or market trends. That's where I spend most of my time. But this time, I want to take you behind the scenes of something different — my journey of building a CRM and property listing management website.

--- a/src/content/talks/table-ronde-tunis-2026.mdx
+++ b/src/content/talks/table-ronde-tunis-2026.mdx
@@ -7,6 +7,7 @@ speakers:
   - id: yasser-foudhil
   - id: sami-belhadj
 language: french
+contentLanguage: french
 ---
 
 Aujourd'hui, on parle beaucoup d'IA dans la tech, mais souvent avec un seul angle.

--- a/src/content/talks/the-ai-career-lift-leveraging-todays-ai-to-stay-relevant-and-outperform.mdx
+++ b/src/content/talks/the-ai-career-lift-leveraging-todays-ai-to-stay-relevant-and-outperform.mdx
@@ -3,6 +3,7 @@ title: "The AI Career Lift: Leveraging Today's AI to Stay Relevant and Outperfor
 speakers:
   - id: ba-ngoc
 language: english
+contentLanguage: english
 ---
 
 AI is no longer a future trend — it's a present-day career multiplier. This talk explores the current stage of AI, what it can realistically do today, and how professionals can leverage it to boost productivity, expand skill sets, and stay competitive. Attendees will leave with practical insights and actionable ways to elevate their careers in the AI era.

--- a/src/content/talks/the-algorithm-of-grief-from-loss-to-legacy.mdx
+++ b/src/content/talks/the-algorithm-of-grief-from-loss-to-legacy.mdx
@@ -3,6 +3,7 @@ title: "The Algorithm of Grief: From Loss to Legacy"
 speakers:
   - id: mohamed-ali-dridi
 language: english
+contentLanguage: english
 vod:
   type: "youtube"
   youtubeId: "p2OLOYG5GuM"

--- a/src/content/talks/the-impact-of-ai-in-ux.mdx
+++ b/src/content/talks/the-impact-of-ai-in-ux.mdx
@@ -3,6 +3,7 @@ title: "The impact of AI in UX"
 speakers:
   - id: marwen-essalah
 language: english
+contentLanguage: english
 ---
 
 In this keynote, Marwen explores the concrete impact of AI on the UX design journey, from user research all the way to handoff. Between dramatically faster processes, new possibilities for exploration, and the automation of repetitive tasks, he raises the real question: are we witnessing a true revolution in the profession, or a powerful yet manageable evolution? A talk that takes a step back from the hype to examine AI's promises, its limits, its risks, and the central role designers must continue to play in creating truly human experiences.

--- a/src/content/talks/the-tests-that-write-themselves-almost.mdx
+++ b/src/content/talks/the-tests-that-write-themselves-almost.mdx
@@ -3,6 +3,7 @@ title: "The Tests That Write Themselves (Almost)"
 speakers:
   - id: nicolas-dubien
 language: english
+contentLanguage: english
 ---
 
 Imagine a world where writing tests doesn't demand years of experience, where considering every edge case is not a requirement, and where expressing your expectations is enough to validate your code. Let's add a glimpse of magic in our tests, let's discover the world of property-based testing!

--- a/src/content/talks/the-web-can-be-weird.mdx
+++ b/src/content/talks/the-web-can-be-weird.mdx
@@ -3,6 +3,7 @@ title: "The web can be weird"
 speakers:
   - id: elian-van-cutsem
 language: english
+contentLanguage: english
 ---
 
 The web is capable of way more than we might think. During this talk, we'll explore some lesser known parts of the web. Did you know you can control the web via webHID or send notes to devices via webMIDI? In this interactive talk we might make some music together, by controlling synthesisers and exploring the wide range of strange web API's

--- a/src/content/talks/unleashing-gemini-superpower-with-chrome-extension.mdx
+++ b/src/content/talks/unleashing-gemini-superpower-with-chrome-extension.mdx
@@ -3,6 +3,7 @@ title: "Unleashing Gemini superpower with Chrome Extension"
 speakers:
   - id: vin-lim
 language: english
+contentLanguage: english
 feedback:
   link: https://openfeedback.io/forkit-kl-2025/2025-10-25/LWfVLMyyGaUBK63NhQ4T
 vod:

--- a/src/content/talks/unlocking-secure-development-managing-secrets-in-your-frontend.mdx
+++ b/src/content/talks/unlocking-secure-development-managing-secrets-in-your-frontend.mdx
@@ -4,5 +4,6 @@ speakers:
   - id: kan-pawarisson
   - id: ioun-nirach
 language: english
+contentLanguage: english
 ---
 In this talk, we'll explore how frontend developers can manage secrets securely without exposing sensitive data to the wrong hands. Learn practical techniques to keep your environment variables safe while maintaining a seamless development experience.

--- a/src/content/talks/ux-design-through-the-eyes-of-an-architect.mdx
+++ b/src/content/talks/ux-design-through-the-eyes-of-an-architect.mdx
@@ -3,6 +3,7 @@ title: "UX Design through the eyes of an Architect"
 speakers:
   - id: alexandra-pituru
 language: english
+contentLanguage: english
 feedback:
   link: https://openfeedback.io/fork-it-community-rouen-2024/2024-06-07/RKSoTn5WZYs7Fzcs5HIj
 vod:

--- a/src/content/talks/we-don-t-want-to-migrate-to-typescript-there-is-too-much-too-learn.mdx
+++ b/src/content/talks/we-don-t-want-to-migrate-to-typescript-there-is-too-much-too-learn.mdx
@@ -3,6 +3,7 @@ title: "We don't want to migrate to TypeScript, there is too much to learn!"
 speakers:
   - id: yoann-fleury
 language: english
+contentLanguage: english
 vod:
   type: youtube
   youtubeId: 5vmA8tbyNlY

--- a/src/content/talks/what-changes-when-current-security-practices-meet-the-blockchain.mdx
+++ b/src/content/talks/what-changes-when-current-security-practices-meet-the-blockchain.mdx
@@ -3,6 +3,7 @@ title: "What Changes When Current Security Practices Meet the Blockchain"
 speakers:
   - id: quy-nguyen
 language: english
+contentLanguage: english
 ---
 
 Most software systems today are built with familiar security practices: trusted administrators, private infrastructure, controlled users, and the ability to fix problems after deployment.

--- a/src/content/talks/yay-i-finished-a-side-project.mdx
+++ b/src/content/talks/yay-i-finished-a-side-project.mdx
@@ -3,6 +3,7 @@ title: "Yay! I finished a side-project !"
 speakers:
   - id: quentin-lerebours
 language: english
+contentLanguage: english
 vod:
   type: youtube
   youtubeId: s8vI4NUGhRo

--- a/src/content/talks/you-should-not-blindly-trust-your-security-scanners-and-here-is-why.mdx
+++ b/src/content/talks/you-should-not-blindly-trust-your-security-scanners-and-here-is-why.mdx
@@ -3,6 +3,7 @@ title: "you should not blindly trust your security scanners and here is why !"
 speakers:
   - id: rachid-zarouali
 language: english
+contentLanguage: english
 feedback:
   link: https://openfeedback.io/forkit-kl-2025/2025-10-25/HuTd2AuncXGtpT7iCMkR
 ---

--- a/src/schemas/talks.ts
+++ b/src/schemas/talks.ts
@@ -25,5 +25,5 @@ export const zTalk = () =>
         youtubeId: z.string(),
       })
       .optional(),
-    contentLanguage: zLanguage().optional().default("english"),
+    contentLanguage: zLanguage(),
   });


### PR DESCRIPTION
French talks were missing their contentLanguage value in the frontmatter, causing them to default to "english" and render with lang="en" in the HTML. Made contentLanguage required in the schema and added the correct value to all 69 talk MDX files that were missing it.