### PR TITLE
fix: swap schedule slots between Eya Laouini and Mathias Arlaud talks…

### DIFF
--- a/src/content/events/2026-tunisia-tunis/index.mdx
+++ b/src/content/events/2026-tunisia-tunis/index.mdx
@@ -64,22 +64,22 @@ schedule:
       startTime: 2026-04-18T10:15:00.000Z
       duration: 15
     - type: conference
-      slug: leveraging-the-expressionlanguage-component-let-your-users-be-creative
+      slug: from-black-box-to-white-box-generative-ai-evaluation-on-googles-vertex-ai
       startTime: 2026-04-18T10:30:00.000Z
-      duration: 30
+      duration: 45
     - type: roundtable
       slug: table-ronde-tunis-2026
-      startTime: 2026-04-18T11:00:00.000Z
+      startTime: 2026-04-18T11:15:00.000Z
       duration: 60
     - type: info
       name: Lunch
       description: Food and networking!
-      startTime: 2026-04-18T12:00:00.000Z
+      startTime: 2026-04-18T12:15:00.000Z
       duration: 90
     - type: conference
-      slug: from-black-box-to-white-box-generative-ai-evaluation-on-googles-vertex-ai
-      startTime: 2026-04-18T13:30:00.000Z
-      duration: 45
+      slug: leveraging-the-expressionlanguage-component-let-your-users-be-creative
+      startTime: 2026-04-18T13:45:00.000Z
+      duration: 30
     - type: conference
       slug: codons-un-maitre-du-jeu-de-role-multi-agents-avec-strands-agents
       startTime: 2026-04-18T14:15:00.000Z


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Tunisia Tunis 2026 event schedule by rescheduling two conference sessions on April 18th. The sessions have been reassigned to new time slots: the first is now at 10:30 AM (30-minute duration) and the second is now at 1:30 PM (45-minute duration). Attendees should refer to the updated schedule for accurate session timing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->