### PR TITLE
feat: add Link header on homepage pointing to /llms.txt

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,9 +1,20 @@
 import { changeLanguage, init } from "@/i18n";
 import { defineMiddleware } from "astro:middleware";
 
-export const onRequest = defineMiddleware(async ({ currentLocale }, next) => {
-  await init();
-  changeLanguage(currentLocale);
+export const onRequest = defineMiddleware(
+  async ({ currentLocale, url }, next) => {
+    await init();
+    changeLanguage(currentLocale);
 
-  return next();
-});
+    const response = await next();
+
+    if (url.pathname === "/") {
+      response.headers.set(
+        "Link",
+        '</llms.txt>; rel="describedby"; type="text/plain"',
+      );
+    }
+
+    return response;
+  },
+);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,20 +1,9 @@
 import { changeLanguage, init } from "@/i18n";
 import { defineMiddleware } from "astro:middleware";
 
-export const onRequest = defineMiddleware(
-  async ({ currentLocale, url }, next) => {
-    await init();
-    changeLanguage(currentLocale);
+export const onRequest = defineMiddleware(async ({ currentLocale }, next) => {
+  await init();
+  changeLanguage(currentLocale);
 
-    const response = await next();
-
-    if (url.pathname === "/") {
-      response.headers.set(
-        "Link",
-        '</llms.txt>; rel="describedby"; type="text/plain"',
-      );
-    }
-
-    return response;
-  },
-);
+  return next();
+});

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,15 @@
 {
+  "headers": [
+    {
+      "source": "/",
+      "headers": [
+        {
+          "key": "Link",
+          "value": "</llms.txt>; rel=\"describedby\"; type=\"text/plain\""
+        }
+      ]
+    }
+  ],
   "redirects": [
     {
       "source": "/meetups/2025-02-12-nabeul",


### PR DESCRIPTION
## Summary
- Adds a `Link` response header on `/` via middleware, pointing agents to the existing `/llms.txt` with `rel="describedby"` (RFC 8288).
- Improves machine discoverability surfaced by audits like isitagentready.com.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated request handling and language initialization logic
  * Added HTTP headers to home page responses to provide resource metadata

<!-- end of auto-generated comment: release notes by coderabbit.ai -->