### PR TITLE
feat: add Content Signals to robots.txt

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -90,6 +90,12 @@ export default defineConfig({
           disallow: ["/branding/components", "/events/*/prospectus"],
         },
       ],
+      transform(content) {
+        return content.replace(
+          /^User-agent: \*$/m,
+          "User-agent: *\nContent-Signal: ai-train=no, search=yes, ai-input=no",
+        );
+      },
     }),
     astrobook({
       subpath: "/branding/components",


### PR DESCRIPTION
## Summary
- Adds a `Content-Signal: ai-train=no, search=yes, ai-input=no` directive to the generated `robots.txt` via the `astro-robots-txt` `transform` hook, declaring AI content usage preferences per the [Content Signals draft spec](https://contentsignals.org/).

## Test plan
- [ ] Run `pnpm build` and confirm `dist/client/robots.txt` contains the `Content-Signal` line immediately after `User-agent: *`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified the robots.txt file generation to include AI content signal directives, specifying policies for search engine access and AI training restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->