### PR TITLE
feat: enable markdown content negotiation for agents

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -10,6 +10,7 @@ import { qrcode } from "vite-plugin-qrcode";
 import node from "@astrojs/node";
 import vercel from "@astrojs/vercel";
 import { getSiteUrl } from "./src/lib/getSiteURL";
+import { markdownNegotiation } from "./src/lib/astro/markdown-negotiation-integration";
 import astrobook from "astrobook";
 
 import bearstudiotypedRoutes from "@bearstudio/astro-typed-routes";
@@ -103,6 +104,7 @@ export default defineConfig({
       title: "Components | Fork it! Community",
     }),
     bearstudiotypedRoutes(),
+    markdownNegotiation(),
   ],
 
   adapter,

--- a/src/lib/astro/markdown-negotiation-integration.ts
+++ b/src/lib/astro/markdown-negotiation-integration.ts
@@ -1,0 +1,69 @@
+import type { AstroIntegration } from "astro";
+import { readFile, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+type VercelRoute = Record<string, unknown>;
+
+const MARKDOWN_NEGOTIATION_ROUTES: VercelRoute[] = [
+  {
+    src: "^/events/([^/]+)$",
+    has: [{ type: "header", key: "accept", value: ".*text/markdown.*" }],
+    dest: "/events/$1.html.md",
+  },
+  {
+    src: "^/people/([^/]+)$",
+    has: [{ type: "header", key: "accept", value: ".*text/markdown.*" }],
+    dest: "/people/$1.html.md",
+  },
+  {
+    src: "^/news/article/([^/]+)$",
+    has: [{ type: "header", key: "accept", value: ".*text/markdown.*" }],
+    dest: "/news/article/$1.html.md",
+  },
+  {
+    src: "^/podcasts/([^/]+)/episodes/([^/]+)$",
+    has: [{ type: "header", key: "accept", value: ".*text/markdown.*" }],
+    dest: "/podcasts/$1/episodes/$2.html.md",
+  },
+];
+
+export const markdownNegotiation = (): AstroIntegration => ({
+  name: "markdown-negotiation",
+  hooks: {
+    "astro:build:done": async ({ dir, logger }) => {
+      const candidates = [
+        new URL("../.vercel/output/config.json", dir),
+        new URL("../../.vercel/output/config.json", dir),
+        new URL("./.vercel/output/config.json", dir),
+      ];
+      const configPath = candidates
+        .map((url) => fileURLToPath(url))
+        .find((path) => existsSync(path));
+
+      if (!configPath) {
+        logger.warn(
+          `Skipping markdown negotiation injection: .vercel/output/config.json not found near ${fileURLToPath(dir)}`,
+        );
+        return;
+      }
+
+      const raw = await readFile(configPath, "utf-8");
+      const config = JSON.parse(raw) as { routes?: VercelRoute[] };
+      const routes = config.routes ?? [];
+
+      const filesystemIndex = routes.findIndex(
+        (route) => route.handle === "filesystem",
+      );
+      const insertionIndex = filesystemIndex === -1 ? 0 : filesystemIndex;
+
+      routes.splice(insertionIndex, 0, ...MARKDOWN_NEGOTIATION_ROUTES);
+      config.routes = routes;
+
+      await writeFile(configPath, JSON.stringify(config, null, 2));
+      logger.info(
+        `Injected ${MARKDOWN_NEGOTIATION_ROUTES.length} markdown negotiation routes before filesystem.`,
+      );
+    },
+  },
+});

--- a/src/pages/events/[id].html.md/index.ts
+++ b/src/pages/events/[id].html.md/index.ts
@@ -46,7 +46,7 @@ ${displayAfterEvent(event)}
 
 ${await displaySponsors(event)}`,
     {
-      headers: { "Content-Type": "text/plain; charset=utf-8" },
+      headers: { "Content-Type": "text/markdown; charset=utf-8" },
     },
   );
 };

--- a/src/pages/people/[id].html.md/index.ts
+++ b/src/pages/people/[id].html.md/index.ts
@@ -26,7 +26,7 @@ ${displaySocial(person)}
 
 ${await displayContribution(person)}`,
     {
-      headers: { "Content-Type": "text/plain; charset=utf-8" },
+      headers: { "Content-Type": "text/markdown; charset=utf-8" },
     },
   );
 };

--- a/src/pages/podcasts/[id]/episodes/[episodes].html.md/index.ts
+++ b/src/pages/podcasts/[id]/episodes/[episodes].html.md/index.ts
@@ -25,7 +25,7 @@ ${await displayHost(id, episodes)}
 
 ${await displayGuest(id, episodes)}`,
     {
-      headers: { "Content-Type": "text/plain; charset=utf-8" },
+      headers: { "Content-Type": "text/markdown; charset=utf-8" },
     },
   );
 };

--- a/vercel.json
+++ b/vercel.json
@@ -10,6 +10,52 @@
       ]
     }
   ],
+  "rewrites": [
+    {
+      "source": "/events/:id",
+      "has": [
+        {
+          "type": "header",
+          "key": "accept",
+          "value": ".*text/markdown.*"
+        }
+      ],
+      "destination": "/events/:id.html.md"
+    },
+    {
+      "source": "/people/:id",
+      "has": [
+        {
+          "type": "header",
+          "key": "accept",
+          "value": ".*text/markdown.*"
+        }
+      ],
+      "destination": "/people/:id.html.md"
+    },
+    {
+      "source": "/news/article/:id",
+      "has": [
+        {
+          "type": "header",
+          "key": "accept",
+          "value": ".*text/markdown.*"
+        }
+      ],
+      "destination": "/news/article/:id.html.md"
+    },
+    {
+      "source": "/podcasts/:id/episodes/:episode",
+      "has": [
+        {
+          "type": "header",
+          "key": "accept",
+          "value": ".*text/markdown.*"
+        }
+      ],
+      "destination": "/podcasts/:id/episodes/:episode.html.md"
+    }
+  ],
   "redirects": [
     {
       "source": "/meetups/2025-02-12-nabeul",

--- a/vercel.json
+++ b/vercel.json
@@ -10,52 +10,6 @@
       ]
     }
   ],
-  "rewrites": [
-    {
-      "source": "/events/:id",
-      "has": [
-        {
-          "type": "header",
-          "key": "accept",
-          "value": ".*text/markdown.*"
-        }
-      ],
-      "destination": "/events/:id.html.md"
-    },
-    {
-      "source": "/people/:id",
-      "has": [
-        {
-          "type": "header",
-          "key": "accept",
-          "value": ".*text/markdown.*"
-        }
-      ],
-      "destination": "/people/:id.html.md"
-    },
-    {
-      "source": "/news/article/:id",
-      "has": [
-        {
-          "type": "header",
-          "key": "accept",
-          "value": ".*text/markdown.*"
-        }
-      ],
-      "destination": "/news/article/:id.html.md"
-    },
-    {
-      "source": "/podcasts/:id/episodes/:episode",
-      "has": [
-        {
-          "type": "header",
-          "key": "accept",
-          "value": ".*text/markdown.*"
-        }
-      ],
-      "destination": "/podcasts/:id/episodes/:episode.html.md"
-    }
-  ],
   "redirects": [
     {
       "source": "/meetups/2025-02-12-nabeul",


### PR DESCRIPTION
## Summary
- Add Vercel header-based rewrites so requests with `Accept: text/markdown` serve the existing `.html.md` endpoints for events, people, news articles, and podcast episodes while browsers still receive HTML by default.
- Normalize `Content-Type` to `text/markdown; charset=utf-8` on the events, people, and podcast episode markdown endpoints (news was already correct).

## Test plan
- [ ] After deploy, run `curl -H "Accept: text/markdown" https://forkit.community/events/<id>` and confirm `Content-Type: text/markdown; charset=utf-8` with a markdown body.
- [ ] Confirm plain browser requests to the same URLs still return HTML.
- [ ] Validate via `POST https://isitagentready.com/api/scan` that `checks.contentAccessibility.markdownNegotiation.status` is `pass`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)