### PR TITLE
feat: add Docaposte and Digit as sponsors for Rouen 2026

### DIFF
--- a/src/content/events/2026-france-rouen/index.mdx
+++ b/src/content/events/2026-france-rouen/index.mdx
@@ -32,8 +32,14 @@ image:
   alt: "Rue Saint Romain à Rouen, France"
   credit: "Niels Bosman"
 sponsoringLevels:
+  - SILVER
+  - BRONZE
   - LOGISTIC
 sponsors:
+  - slug: docaposte
+    level: SILVER
+  - slug: digit
+    level: BRONZE
   - slug: village-by-ca
     level: LOGISTIC
 faq:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated sponsorship structure for the 2026 Rouen event with new SILVER and BRONZE sponsorship tiers and two additional sponsors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->