### PR TITLE
fix: replace docaposte by agility in next rouen event

### DIFF
--- a/src/content/events/2026-france-rouen/index.mdx
+++ b/src/content/events/2026-france-rouen/index.mdx
@@ -36,7 +36,7 @@ sponsoringLevels:
   - BRONZE
   - LOGISTIC
 sponsors:
-  - slug: docaposte
+  - slug: docaposte-agility
     level: SILVER
   - slug: digit
     level: BRONZE


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated sponsor information for the Rouen 2026 event, replacing one sponsor identifier while maintaining existing sponsor tier assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->