### PR TITLE
fix: cfp end date

### DIFF
--- a/src/content/events/2026-france-rouen/index.mdx
+++ b/src/content/events/2026-france-rouen/index.mdx
@@ -13,7 +13,7 @@ prospectus:
   href: https://drive.google.com/drive/folders/16JZ1qHliGan2tkGMACDABhiRbmWDfUfv
 cfp:
   href: https://conference-hall.io/fork-it-community-france-rouen-2026
-  end: 2026-04-19T23:59:00.000Z
+  endDate: 2026-04-20T23:59:00.000Z
 organizers:
   - person: rudy-baer
   - person: yoann-fleury


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended the Call for Papers deadline for the 2026 Rouen France event by one day.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->