### PR TITLE
feat: add Abeba NGWE biography

### DIFF
--- a/src/content/people/abeba-ngwe/index.mdx
+++ b/src/content/people/abeba-ngwe/index.mdx
@@ -1,5 +1,5 @@
 ---
-bioLang: english
+bioLang: french
 name: Abeba NGWE
 avatar: ./abeba-ngwe.jpg
 job: Front-end developer
@@ -14,3 +14,11 @@ socials:
   - type: "website"
     href: https://www.alorsondev.com/
 ---
+
+Abeba Ngwe est développeuse front-end chez leboncoin, où elle évolue dans un monorepo Next.js au sein d'une guilde de plus de 60 développeurs.
+
+Créatrice de la chaîne YouTube [Alors on dev](https://www.youtube.com/@Alorsondev), elle est également l'autrice du livre *[Réussir ses tests techniques en développement web](https://www.alorsondev.com/reussir-ses-tests-techniques/MdOxj)* (2024) et invitée dans plusieurs podcasts tech.
+
+Early adopter des outils d'IA en développement, elle a contribué à structurer l'usage du context engineering dans sa guilde : skills, agents spécialisés, fichiers de contexte, workflows. Son approche mêle retour d'expérience concret et recul critique : comment utiliser l'IA pour gagner en efficacité sans tomber dans l'obsession du contrôle.
+
+Elle explore aujourd'hui une conviction simple : déléguer intelligemment les tâches répétitives permet de maximiser ce que les développeurs aiment vraiment faire — réfléchir.


### PR DESCRIPTION
## Summary
- Add French biography for Abeba NGWE on her speaker page
- Switch `bioLang` from `english` to `french` to match the content

## Test plan
- [ ] Verify the bio renders correctly on Abeba NGWE's speaker page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Documentation**
- Updated the biography section for Abeba Ngwe, now featuring French language content. The profile includes details about her professional background at leboncoin, her YouTube presence, appearances in books and podcasts, her work in context engineering with AI, and insights on automating repetitive development tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->