### PR TITLE
feat: clamp keynote description with Read more + add Ivan Dalmet Rouen 2026 keynote

### DIFF
--- a/src/components/KeynoteReadMoreButton/index.tsx
+++ b/src/components/KeynoteReadMoreButton/index.tsx
@@ -1,0 +1,45 @@
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils-client";
+import { useEffect, useState } from "react";
+import { MdArrowForward } from "react-icons/md";
+
+interface Props {
+  href: string;
+  targetId: string;
+}
+
+export const KeynoteReadMoreButton = ({ href, targetId }: Props) => {
+  const [isOverflowing, setIsOverflowing] = useState(false);
+
+  useEffect(() => {
+    const target = document.getElementById(targetId);
+    if (!target) return;
+
+    const checkOverflow = () => {
+      setIsOverflowing(target.scrollHeight > target.clientHeight + 1);
+    };
+
+    checkOverflow();
+    document.fonts?.ready.then(checkOverflow);
+
+    const observer = new ResizeObserver(checkOverflow);
+    observer.observe(target);
+
+    return () => observer.disconnect();
+  }, [targetId]);
+
+  if (!isOverflowing) return null;
+
+  return (
+    <a
+      href={href}
+      className={cn(
+        buttonVariants({ variant: "link-neutral", size: "sm" }),
+        "w-fit gap-2 px-0",
+      )}
+    >
+      Read more
+      <MdArrowForward />
+    </a>
+  );
+};

--- a/src/components/KeynoteSection/index.astro
+++ b/src/components/KeynoteSection/index.astro
@@ -1,4 +1,5 @@
 ---
+import { KeynoteReadMoreButton } from "@/components/KeynoteReadMoreButton";
 import Prose from "@/components/Prose/index.astro";
 import { lunalink } from "@bearstudio/lunalink";
 import { ROUTES } from "@/routes.gen";
@@ -12,12 +13,19 @@ interface Props {
   talk: CollectionEntry<"talks">;
   speakers: CollectionEntry<"people">[];
   period?: KeynotePeriod;
+  eventId: string;
 }
 
-const { talk, speakers, period } = Astro.props;
+const { talk, speakers, period, eventId } = Astro.props;
 
 const { Content } = await render(talk);
 const hasContent = talk.body && talk.body.trim().length > 0;
+
+const talkHref = lunalink(ROUTES.events[":id"].talks[":talkId"].__path, {
+  id: eventId,
+  talkId: talk.id,
+});
+const clampId = `keynote-clamp-${talk.id}`;
 ---
 
 <div class="relative mx-auto flex w-full max-w-screen-lg flex-col gap-12 px-4">
@@ -70,9 +78,16 @@ const hasContent = talk.body && talk.body.trim().length > 0;
 
       {
         hasContent ? (
-          <Prose>
-            <Content />
-          </Prose>
+          <div class="flex flex-col gap-4">
+            <Prose class="line-clamp-[7]" id={clampId}>
+              <Content />
+            </Prose>
+            <KeynoteReadMoreButton
+              client:load
+              href={talkHref}
+              targetId={clampId}
+            />
+          </div>
         ) : (
           <p class="text-white">
             Keynote details coming soon! Stay tuned for updates.

--- a/src/components/Prose/index.astro
+++ b/src/components/Prose/index.astro
@@ -4,11 +4,13 @@ import { cn } from "@/lib/utils-client";
 interface Props {
   class?: string;
   lang?: string;
+  id?: string;
 }
-const { class: className, lang } = Astro.props;
+const { class: className, lang, id } = Astro.props;
 ---
 
 <div
+  id={id}
   lang={lang}
   class={cn(
     // Base

--- a/src/content/talks/keynote-ivan-dalmet-rouen-2026.mdx
+++ b/src/content/talks/keynote-ivan-dalmet-rouen-2026.mdx
@@ -1,7 +1,15 @@
 ---
-title: "Title to be announced"
+title: "The Design Assembly Line"
 speakers:
   - id: ivan-dalmet
-language: french
-contentLanguage: french
+language: english
+contentLanguage: english
 ---
+
+For years, we pretended this was normal: the business talks to the product manager, who translates to the designer, who churns out static mockups, which the developer translates back into code. An endless cascade of translations, and a mountain of hidden costs everyone has learned to ignore.
+
+AI is reshuffling the deck, but not where you'd expect. The real point isn't to spit out throwaway prototypes that end up in the trash. It's to design in an isolated environment that's genuinely wired into the production codebase. No more mockups that lie: time for iteration that speaks the same language as the final code.
+
+And from there, everything shifts. The bottleneck has moved: producing has become fast, it's deciding that slows things down. Business teams and PMs test their ideas live, designers stop pushing pixels and reclaim their role as captains of the user experience, and developers finally get something concrete instead of specs to interpret. Roles are being redrawn. So is the organization.
+
+What's left are the real questions, the ones we rarely ask in time: what do we keep under our control, what do we hand off to the machine, and on what, or whom, are we willing to become dependent to get there?

--- a/src/pages/events/[id]/index.astro
+++ b/src/pages/events/[id]/index.astro
@@ -486,6 +486,7 @@ const validKeynotes = keynoteSection.filter(
             talk={talk!}
             speakers={speakers}
             period={item.period!}
+            eventId={event.id}
           />
         ))}
       </div>


### PR DESCRIPTION
## Summary
- Add Ivan Dalmet's Rouen 2026 opening keynote content: title "The Design Assembly Line" + full english abstract
- Clamp the keynote description to 7 lines on the event page so the section stays compact
- Hydrate a small React `KeynoteReadMoreButton` that measures the clamped element and only renders the "Read more" link when the description actually overflows; the talk detail page still shows the full description

## Test plan
- [ ] On `/events/2026-france-rouen`, the Opening Keynote section shows the new title and a 7-line preview of the abstract followed by a "Read more" link that navigates to the talk detail page
- [ ] On `/events/2026-france-rouen/talks/keynote-ivan-dalmet-rouen-2026`, the full description is rendered (no clamp)
- [ ] For keynotes whose description fits in 7 lines, no "Read more" link is shown
- [ ] Resize the window: the "Read more" link appears/disappears as the content starts/stops overflowing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Keynote talks that exceed the display limit now show a "Read more" button, enabling users to easily access and read the complete presentation content.

* **Content Updates**
  * Updated a keynote presentation with a new title and comprehensive content explaining the design assembly line methodology for modern design and development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->