### PR TITLE
feat: rename Ivan Dalmet keynote to "The Product Design Assembly Line"

### DIFF
--- a/src/content/talks/keynote-ivan-dalmet-rouen-2026.mdx
+++ b/src/content/talks/keynote-ivan-dalmet-rouen-2026.mdx
@@ -1,5 +1,5 @@
 ---
-title: "The Design Assembly Line"
+title: "The Product Design Assembly Line"
 speakers:
   - id: ivan-dalmet
 language: english


### PR DESCRIPTION
## Summary
- Update Ivan Dalmet's Rouen 2026 keynote title from "The Design Assembly Line" to "The Product Design Assembly Line".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated keynote presentation title for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->