### PR TITLE
feat(rouen-2026): add BearStudio as silver sponsor and React Advanced as partner

### DIFF
--- a/src/content/events/2026-france-rouen/index.mdx
+++ b/src/content/events/2026-france-rouen/index.mdx
@@ -38,10 +38,14 @@ sponsoringLevels:
 sponsors:
   - slug: docaposte-agility
     level: SILVER
+  - slug: bearstudio
+    level: SILVER
   - slug: digit
     level: BRONZE
   - slug: village-by-ca
     level: LOGISTIC
+partners:
+  - react-advanced
 faq:
   - question: How many tickets are available for the event?
     answer: There are 30 early bird tickets and 200 tickets in total, followed by 20 late bird tickets.


### PR DESCRIPTION
Adds BearStudio as a silver sponsor and React Advanced London as a partner for the Fork it! Community Rouen 2026 event.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Added a new partner to the 2026 France Rouen event.
  * Added a new Silver-level sponsor to the 2026 France Rouen event.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->