### PR TITLE
fix(talks): correct essay reference in Clément Delafargue talk

### DIFF
--- a/src/content/talks/bon-cest-bien-joli-vos-technos-de-hipster-mais-moi-je-fais-de-la-prod.mdx
+++ b/src/content/talks/bon-cest-bien-joli-vos-technos-de-hipster-mais-moi-je-fais-de-la-prod.mdx
@@ -9,7 +9,7 @@ contentLanguage: french
 J'ai eu la chance de travailler avec des technologies _avant gardistes_, scala à partir de 2010, puis haskell, et désormais rust.
 Évidemment d'un point de vue de dev c'était cool, mais c'est toujours difficile à justifier au top management qui ne comprend pas la beauté d'un système de types expressif et nous embête avec des histoires de recrutement, de formation, de gestion d'équipe.
 
-Un des textes qui revient souvent dans le domaine, c'est « hackers & painters », un essai pour le moins auto-satisfait et suffisant, qui justifie les technos alternatives par une vélocité décuplée. Avec le recul de ces quatre expériences, je pense que cet essai n'est plus totalement d'actualité et j'aimerais le mitiger quelque peu.
+Un des textes qui revient souvent dans le domaine, c'est « beating the averages », un essai pour le moins auto-satisfait et suffisant, qui justifie les technos alternatives par une vélocité décuplée. Avec le recul de ces quatre expériences, je pense que cet essai n'est plus totalement d'actualité et j'aimerais le mitiger quelque peu.
 
 Au programme :
 


### PR DESCRIPTION
Update essay title from "hackers & painters" to "beating the averages", which is the correct essay being referenced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated citation references in talk content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->