### PR TITLE
feat(rouen-2026): tentative schedule with locations and schedule card refinements

### DIFF
--- a/src/components/Conferences/ConferenceCard.astro
+++ b/src/components/Conferences/ConferenceCard.astro
@@ -79,7 +79,7 @@ const { Content } = await render(conference);
       class="flex w-fit items-center gap-1.5 rounded-full border border-black/60 bg-black/40 px-2 py-0.5 text-2xs font-bold uppercase leading-none opacity-60 transition group-hover:opacity-100"
     >
       <IoLanguageSharp className="text-base" />
-      <span>Talk in {conference.data.language}</span>
+      <span>in {conference.data.language}</span>
     </span>
     {
       conference.data.vod && conference.data.vod.youtubeId && (

--- a/src/components/Schedule/CardConference.astro
+++ b/src/components/Schedule/CardConference.astro
@@ -44,8 +44,6 @@ const scheduleItem = (event.data.schedule?.items ?? []).find(
       })}
       class={cn(
         "group flex w-full flex-col gap-4 rounded-lg bg-white/5 p-4 backdrop-blur-md transition hover:bg-white/10 sm:px-6 sm:py-5",
-        scheduleItem?.type === "workshop" &&
-          "bg-primary/10 hover:bg-primary/15",
         scheduleItem?.status === "cancelled" && "opacity-60",
       )}
     >

--- a/src/components/Schedule/CardConference.astro
+++ b/src/components/Schedule/CardConference.astro
@@ -50,17 +50,13 @@ const scheduleItem = (event.data.schedule?.items ?? []).find(
       <div class="flex items-start justify-between gap-2">
         <p
           class={cn(
-            "text-balance font-heading text-base font-medium leading-tight tracking-wider text-white transition group-hover:text-primary",
+            "text-pretty font-heading text-base font-medium leading-tight tracking-wider text-white transition group-hover:text-primary",
             scheduleItem?.status === "cancelled" && "line-through",
           )}
         >
           {talk.data.title}
         </p>
-        <div class="flex items-center gap-2">
-          {(scheduleItem?.type === "keynote" ||
-            scheduleItem?.type === "workshop") && (
-            <Badge variant="card">{scheduleItem.type}</Badge>
-          )}
+        <div class="flex shrink-0 items-center gap-2">
           {scheduleItem?.status === "cancelled" && (
             <div class="h-full w-fit rounded-full bg-white/10 px-2 py-1 text-white">
               <div class="flex items-center gap-1">
@@ -105,10 +101,7 @@ const scheduleItem = (event.data.schedule?.items ?? []).find(
       >
         <Badge variant="card">
           <IoLanguageSharp className="text-base" />
-          <span>
-            {scheduleItem?.type === "workshop" ? "Workshop" : "Talk"} in{" "}
-            {talk.data.language}
-          </span>
+          <span>in {talk.data.language}</span>
         </Badge>
         {talk.data.vod && talk.data.vod.youtubeId && (
           <Badge variant="card">

--- a/src/components/Schedule/index.astro
+++ b/src/components/Schedule/index.astro
@@ -7,6 +7,7 @@ import type { CollectionEntry } from "astro:content";
 import { MdPlace } from "react-icons/md";
 import { match } from "ts-pattern";
 import TiltedCard from "@/components/TiltedCard";
+import { Badge } from "@/components/ui/badge";
 
 interface Props {
   displayStats?: boolean;
@@ -55,12 +56,18 @@ const { event, displayStats } = Astro.props;
       <div class="flex flex-col">
         {(event.data.schedule.status === "preview"
           ? event.data.schedule.items
-          : event.data.schedule.items.toSorted(
-              (talk1, talk2) =>
-                // Infinity to set startTime=null at the end
-                (talk1.startTime?.valueOf() ?? Infinity) -
-                (talk2.startTime?.valueOf() ?? Infinity),
-            )
+          : event.data.schedule.items.toSorted((talk1, talk2) => {
+              // Infinity to set startTime=null at the end
+              const time1 = talk1.startTime?.valueOf() ?? Infinity;
+              const time2 = talk2.startTime?.valueOf() ?? Infinity;
+              if (time1 !== time2) return time1 - time2;
+              // Workshops first when starting at the same time
+              if (talk1.type === "workshop" && talk2.type !== "workshop")
+                return -1;
+              if (talk1.type !== "workshop" && talk2.type === "workshop")
+                return 1;
+              return 0;
+            })
         ).map((activity) => {
           return (
             <div class="group flex gap-3">
@@ -70,11 +77,62 @@ const { event, displayStats } = Astro.props;
               </div>
               <div class="flex w-full flex-col gap-2 pb-6">
                 <div class="flex flex-1 flex-row flex-wrap items-center justify-between gap-x-3 gap-y-1">
-                  <TimeAndDuration
-                    startTime={activity.startTime}
-                    duration={activity.duration}
-                    class="font-heading text-sm tracking-wide opacity-80"
-                  />
+                  <div class="flex items-center gap-2">
+                    <TimeAndDuration
+                      startTime={activity.startTime}
+                      class="font-heading text-sm tracking-wide opacity-80"
+                    />
+                    {match(activity.type)
+                      .with("conference", () => (
+                        <Badge variant="card" className="py-1">
+                          <span>Talk</span>
+                          {!!activity.duration && (
+                            <>
+                              <span class="opacity-60">·</span>
+                              <span>{activity.duration} min</span>
+                            </>
+                          )}
+                        </Badge>
+                      ))
+                      .with("roundtable", () => (
+                        <Badge variant="card" className="py-1">
+                          <span>Roundtable</span>
+                          {!!activity.duration && (
+                            <>
+                              <span class="opacity-60">·</span>
+                              <span>{activity.duration} min</span>
+                            </>
+                          )}
+                        </Badge>
+                      ))
+                      .with("workshop", () => (
+                        <Badge variant="card" className="py-1">
+                          <span>Workshop</span>
+                          {!!activity.duration && (
+                            <>
+                              <span class="opacity-60">·</span>
+                              <span>{activity.duration} min</span>
+                            </>
+                          )}
+                        </Badge>
+                      ))
+                      .with("keynote", () => (
+                        <Badge
+                          variant="card"
+                          className="border-white/40 bg-white/20 py-1 opacity-100"
+                        >
+                          <span>Keynote</span>
+                          {!!activity.duration && (
+                            <>
+                              <span class="opacity-60">·</span>
+                              <span>{activity.duration} min</span>
+                            </>
+                          )}
+                        </Badge>
+                      ))
+                      .with("info", "lunch", () => null)
+                      .exhaustive()}
+                  </div>
                   {!!activity.location &&
                     (activity.locationUrl ? (
                       <a

--- a/src/components/Schedule/index.astro
+++ b/src/components/Schedule/index.astro
@@ -60,13 +60,7 @@ const { event, displayStats } = Astro.props;
               // Infinity to set startTime=null at the end
               const time1 = talk1.startTime?.valueOf() ?? Infinity;
               const time2 = talk2.startTime?.valueOf() ?? Infinity;
-              if (time1 !== time2) return time1 - time2;
-              // Workshops first when starting at the same time
-              if (talk1.type === "workshop" && talk2.type !== "workshop")
-                return -1;
-              if (talk1.type !== "workshop" && talk2.type === "workshop")
-                return 1;
-              return 0;
+              return time1 - time2;
             })
         ).map((activity) => {
           return (

--- a/src/components/VideoCard/index.astro
+++ b/src/components/VideoCard/index.astro
@@ -45,7 +45,7 @@ const { talk, class: className } = Astro.props;
       class="mt-4 flex w-fit items-center gap-1.5 rounded-full border border-black/60 bg-black/40 px-2 py-0.5 text-2xs font-bold uppercase leading-none opacity-60 transition group-hover:opacity-100"
     >
       <IoLanguageSharp className="text-base" />
-      <span>in {talk.data.language}</span>
+      <span>Talk in {talk.data.language}</span>
     </div>
   </div>
 </a>

--- a/src/components/VideoCard/index.astro
+++ b/src/components/VideoCard/index.astro
@@ -45,7 +45,7 @@ const { talk, class: className } = Astro.props;
       class="mt-4 flex w-fit items-center gap-1.5 rounded-full border border-black/60 bg-black/40 px-2 py-0.5 text-2xs font-bold uppercase leading-none opacity-60 transition group-hover:opacity-100"
     >
       <IoLanguageSharp className="text-base" />
-      <span>Talk in {talk.data.language}</span>
+      <span>in {talk.data.language}</span>
     </div>
   </div>
 </a>

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -15,7 +15,7 @@ const badgeVariants = cva(
         destructive:
           "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
         outline: "text-foreground",
-        card: "flex w-fit items-center gap-1.5 rounded-full border border-black/60 bg-black/40 px-2 py-0.5 text-2xs font-bold uppercase leading-none opacity-60 transition group-hover:opacity-100",
+        card: "flex w-fit items-center gap-1.5 rounded-full border border-white/20 bg-white/10 px-2 py-0.5 text-2xs font-bold uppercase leading-none opacity-60 transition group-hover:opacity-100",
       },
     },
     defaultVariants: {

--- a/src/content/events/2026-france-rouen/index.mdx
+++ b/src/content/events/2026-france-rouen/index.mdx
@@ -74,50 +74,32 @@ schedule:
     - type: keynote
       slug: keynote-ivan-dalmet-rouen-2026
       period: opening
-      startTime: 2026-06-05T09:00:00.000Z
-      duration: 30
       location: Main stage
     - type: conference
       slug: maintaining-open-source-at-the-age-of-ai
-      startTime: 2026-06-05T09:30:00.000Z
-      duration: 30
       location: Main stage
     - type: conference
       slug: my-toxic-relationship-with-ai
-      startTime: 2026-06-05T10:00:00.000Z
-      duration: 45
       location: Main stage
     - type: conference
       slug: bon-cest-bien-joli-vos-technos-de-hipster-mais-moi-je-fais-de-la-prod
-      startTime: 2026-06-05T10:45:00.000Z
-      duration: 45
-      location: Main stage
-    - type: conference
-      slug: je-me-marie-dans-un-mois-patcher-ma-wedding-planner-en-prod
-      startTime: 2026-06-05T11:30:00.000Z
-      duration: 15
       location: Main stage
     - type: keynote
       slug: keynote-quentin-adam-rouen-2026
       period: afternoon
-      startTime: 2026-06-05T13:30:00.000Z
-      duration: 30
+      location: Main stage
+    - type: conference
+      slug: plain-pattern-language-une-book-review-sur-lorigine-des-design-patterns
+      location: Main stage
+    - type: conference
+      slug: je-me-marie-dans-un-mois-patcher-ma-wedding-planner-en-prod
       location: Main stage
     - type: workshop
       slug: construisez-votre-propre-micro-service-en-construisant-votre-propre-os
-      startTime: 2026-06-05T10:00:00.000Z
-      duration: 120
       location: Workshop room
-    - type: conference
-      slug: plain-pattern-language-une-book-review-sur-lorigine-des-design-patterns
-      startTime: 2026-06-05T14:00:00.000Z
-      duration: 45
-      location: Main stage
     - type: keynote
       slug: mon-apple-2-a-moi-sur-breadboard
       period: closing
-      startTime: 2026-06-05T16:00:00.000Z
-      duration: 30
       location: Main stage
 subPages:
   - 2026-france-rouen/pages/informations

--- a/src/content/events/2026-france-rouen/index.mdx
+++ b/src/content/events/2026-france-rouen/index.mdx
@@ -76,40 +76,49 @@ schedule:
       period: opening
       startTime: 2026-06-05T09:00:00.000Z
       duration: 30
+      location: Main stage
     - type: conference
       slug: maintaining-open-source-at-the-age-of-ai
       startTime: 2026-06-05T09:30:00.000Z
       duration: 30
+      location: Main stage
     - type: conference
       slug: my-toxic-relationship-with-ai
       startTime: 2026-06-05T10:00:00.000Z
       duration: 45
+      location: Main stage
     - type: conference
       slug: bon-cest-bien-joli-vos-technos-de-hipster-mais-moi-je-fais-de-la-prod
       startTime: 2026-06-05T10:45:00.000Z
       duration: 45
+      location: Main stage
     - type: conference
       slug: je-me-marie-dans-un-mois-patcher-ma-wedding-planner-en-prod
       startTime: 2026-06-05T11:30:00.000Z
       duration: 15
+      location: Main stage
     - type: keynote
       slug: keynote-quentin-adam-rouen-2026
       period: afternoon
       startTime: 2026-06-05T13:30:00.000Z
       duration: 30
+      location: Main stage
     - type: workshop
       slug: construisez-votre-propre-micro-service-en-construisant-votre-propre-os
       startTime: 2026-06-05T10:00:00.000Z
       duration: 120
+      location: Workshop room
     - type: conference
       slug: plain-pattern-language-une-book-review-sur-lorigine-des-design-patterns
       startTime: 2026-06-05T14:00:00.000Z
       duration: 45
+      location: Main stage
     - type: keynote
       slug: mon-apple-2-a-moi-sur-breadboard
       period: closing
       startTime: 2026-06-05T16:00:00.000Z
       duration: 30
+      location: Main stage
 subPages:
   - 2026-france-rouen/pages/informations
   - 2026-france-rouen/pages/weekend

--- a/src/content/events/2026-france-rouen/index.mdx
+++ b/src/content/events/2026-france-rouen/index.mdx
@@ -74,32 +74,41 @@ schedule:
     - type: keynote
       slug: keynote-ivan-dalmet-rouen-2026
       period: opening
+      startTime: 2026-06-05T09:00:00.000Z
       duration: 30
     - type: conference
       slug: maintaining-open-source-at-the-age-of-ai
+      startTime: 2026-06-05T09:30:00.000Z
       duration: 30
     - type: conference
       slug: my-toxic-relationship-with-ai
+      startTime: 2026-06-05T10:00:00.000Z
       duration: 45
     - type: conference
       slug: bon-cest-bien-joli-vos-technos-de-hipster-mais-moi-je-fais-de-la-prod
-      duration: 45
-    - type: conference
-      slug: plain-pattern-language-une-book-review-sur-lorigine-des-design-patterns
+      startTime: 2026-06-05T10:45:00.000Z
       duration: 45
     - type: conference
       slug: je-me-marie-dans-un-mois-patcher-ma-wedding-planner-en-prod
+      startTime: 2026-06-05T11:30:00.000Z
       duration: 15
-    - type: workshop
-      slug: construisez-votre-propre-micro-service-en-construisant-votre-propre-os
-      duration: 120
     - type: keynote
       slug: keynote-quentin-adam-rouen-2026
       period: afternoon
+      startTime: 2026-06-05T13:30:00.000Z
       duration: 30
+    - type: workshop
+      slug: construisez-votre-propre-micro-service-en-construisant-votre-propre-os
+      startTime: 2026-06-05T10:00:00.000Z
+      duration: 120
+    - type: conference
+      slug: plain-pattern-language-une-book-review-sur-lorigine-des-design-patterns
+      startTime: 2026-06-05T14:00:00.000Z
+      duration: 45
     - type: keynote
       slug: mon-apple-2-a-moi-sur-breadboard
       period: closing
+      startTime: 2026-06-05T16:00:00.000Z
       duration: 30
 subPages:
   - 2026-france-rouen/pages/informations

--- a/src/pages/events/[id]/talks/[talkId]/index.astro
+++ b/src/pages/events/[id]/talks/[talkId]/index.astro
@@ -224,11 +224,7 @@ const talkDetails: EventDetails = {
               class="flex w-fit items-center gap-1.5 rounded-full border border-black/60 bg-black/40 px-2 py-0.5 text-2xs font-bold uppercase leading-none"
             >
               <IoLanguageSharp className="text-base" />
-              <span>
-                {schedule?.type === "workshop" ? "Workshop" : "Talk"} in {
-                  talk.data.language
-                }
-              </span>
+              <span>in {talk.data.language}</span>
             </span>
           </div>
         </div>

--- a/src/pages/events/[id]/talks/[talkId]/index.astro
+++ b/src/pages/events/[id]/talks/[talkId]/index.astro
@@ -22,6 +22,8 @@ import { getGoogleCalendarNewEventUrl } from "@/lib/events.ts";
 import type { EventDetails } from "@/lib/events.ts";
 import { AddToGoogleCalendar } from "@/components/AddToGoogleCalendar";
 import { pastEvent } from "@/lib/utils";
+import { Badge } from "@/components/ui/badge";
+import { match } from "ts-pattern";
 
 export async function getStaticPaths() {
   const events = await getEventsCollection();
@@ -218,15 +220,23 @@ const talkDetails: EventDetails = {
           }
         </div>
         <h1 lang={lang(talk.data.contentLanguage)}>{talk.data.title}</h1>
-        <div class="flex gap-2">
-          <div>
-            <span
-              class="flex w-fit items-center gap-1.5 rounded-full border border-black/60 bg-black/40 px-2 py-0.5 text-2xs font-bold uppercase leading-none"
-            >
-              <IoLanguageSharp className="text-base" />
-              <span>in {talk.data.language}</span>
-            </span>
-          </div>
+        <div class="not-prose flex flex-wrap gap-2">
+          {
+            schedule?.type &&
+              match(schedule.type)
+                .with("conference", () => <Badge variant="card">Talk</Badge>)
+                .with("roundtable", () => (
+                  <Badge variant="card">Roundtable</Badge>
+                ))
+                .with("workshop", () => <Badge variant="card">Workshop</Badge>)
+                .with("keynote", () => <Badge variant="card">Keynote</Badge>)
+                .with("info", "lunch", () => null)
+                .exhaustive()
+          }
+          <Badge variant="card">
+            <IoLanguageSharp className="text-base" />
+            <span>in {talk.data.language}</span>
+          </Badge>
         </div>
         {
           talk.data.vod && talk.data.vod.type === "youtube" && (


### PR DESCRIPTION
## Summary
- Adds tentative startTimes and locations (Main stage / Workshop room) to the Rouen 2026 schedule, with the unikernel workshop running in parallel with morning talks
- Adds a Talk/Workshop/Keynote/Roundtable badge (with duration) before each schedule entry, and sorts workshops first when they start at the same time
- Drops the redundant "Talk in" prefix on language badges, switches the card badge variant to a white-tinted bg/border for better visibility on dark backgrounds, and uses text-pretty for talk titles

## Test plan
- [ ] Visit `/events/2026-france-rouen` and confirm each entry shows its type+duration badge before the time
- [ ] Confirm the workshop appears above the 10:00 talk (same start time) and shows "Workshop room" location
- [ ] Confirm language badges read "in {language}" and the card badge is legible against the dark background