### PR TITLE
feat(rouen-2026): add schedule times and update room names

### DIFF
--- a/src/content/events/2026-france-rouen/index.mdx
+++ b/src/content/events/2026-france-rouen/index.mdx
@@ -71,49 +71,85 @@ lumaEventId: "evt-jwfm6qJKisHP0mz"
 schedule:
   status: not-final
   items:
+    - type: info
+      name: Opening
+      startTime: 2026-06-05T09:00:00.000Z
+      duration: 15
+      location: Auditorium Normandie - Seine
     - type: keynote
       slug: keynote-ivan-dalmet-rouen-2026
       period: opening
+      startTime: 2026-06-05T09:20:00.000Z
       duration: 30
-      location: Main stage
+      location: Auditorium Normandie - Seine
     - type: conference
       slug: maintaining-open-source-at-the-age-of-ai
+      startTime: 2026-06-05T09:55:00.000Z
       duration: 30
-      location: Main stage
+      location: Auditorium Normandie - Seine
+    - type: info
+      name: To Be Defined
+      startTime: 2026-06-05T10:30:00.000Z
+      duration: 15
+      location: Auditorium Normandie - Seine
+    - type: info
+      name: Pause
+      startTime: 2026-06-05T10:50:00.000Z
+      duration: 20
     - type: conference
       slug: my-toxic-relationship-with-ai
+      startTime: 2026-06-05T11:10:00.000Z
       duration: 45
-      location: Main stage
-    - type: conference
-      slug: bon-cest-bien-joli-vos-technos-de-hipster-mais-moi-je-fais-de-la-prod
+      location: Auditorium Normandie - Seine
+    - type: roundtable
+      name: "IA & software delivery : ce qui change vraiment pour les équipes tech"
+      startTime: 2026-06-05T12:00:00.000Z
       duration: 45
-      location: Main stage
+      location: Auditorium Normandie - Seine
+    - type: lunch
+      name: Lunch
+      startTime: 2026-06-05T12:50:00.000Z
+      duration: 80
     - type: keynote
       slug: keynote-quentin-adam-rouen-2026
       period: afternoon
+      startTime: 2026-06-05T14:10:00.000Z
       duration: 30
-      location: Main stage
-    - type: conference
-      slug: plain-pattern-language-une-book-review-sur-lorigine-des-design-patterns
-      duration: 45
-      location: Main stage
-    - type: conference
-      slug: je-me-marie-dans-un-mois-patcher-ma-wedding-planner-en-prod
-      duration: 15
-      location: Main stage
+      location: Auditorium Normandie - Seine
     - type: conference
       slug: my-ai-clone-attended-conferences-while-i-flew-planes
+      startTime: 2026-06-05T14:45:00.000Z
+      duration: 30
+      location: Auditorium Normandie - Seine
+    - type: conference
+      slug: plain-pattern-language-une-book-review-sur-lorigine-des-design-patterns
+      startTime: 2026-06-05T15:20:00.000Z
       duration: 45
-      location: Main stage
-    - type: workshop
-      slug: construisez-votre-propre-micro-service-en-construisant-votre-propre-os
-      location: Workshop room
-      duration: 120
+      location: Auditorium Normandie - Seine
+    - type: info
+      name: Pause
+      startTime: 2026-06-05T16:10:00.000Z
+      duration: 20
+    - type: conference
+      slug: bon-cest-bien-joli-vos-technos-de-hipster-mais-moi-je-fais-de-la-prod
+      startTime: 2026-06-05T16:30:00.000Z
+      duration: 45
+      location: Auditorium Normandie - Seine
+    - type: conference
+      slug: je-me-marie-dans-un-mois-patcher-ma-wedding-planner-en-prod
+      startTime: 2026-06-05T17:20:00.000Z
+      duration: 15
+      location: Auditorium Normandie - Seine
     - type: keynote
       slug: mon-apple-2-a-moi-sur-breadboard
       period: closing
+      startTime: 2026-06-05T17:40:00.000Z
       duration: 30
-      location: Main stage
+      location: Auditorium Normandie - Seine
+    - type: workshop
+      slug: construisez-votre-propre-micro-service-en-construisant-votre-propre-os
+      location: Salle Les Quais
+      duration: 120
 subPages:
   - 2026-france-rouen/pages/informations
   - 2026-france-rouen/pages/weekend

--- a/src/content/events/2026-france-rouen/index.mdx
+++ b/src/content/events/2026-france-rouen/index.mdx
@@ -102,7 +102,7 @@ schedule:
       duration: 45
       location: Auditorium Normandie - Seine
     - type: roundtable
-      name: "IA & software delivery : ce qui change vraiment pour les équipes tech"
+      name: To Be Defined
       startTime: 2026-06-05T12:00:00.000Z
       duration: 45
       location: Auditorium Normandie - Seine


### PR DESCRIPTION
## Summary
- Renamed locations: \`Main stage\` → \`Auditorium Normandie - Seine\`, \`Workshop room\` → \`Salle Les Quais\`.
- Added \`startTime\` for each main-stage item per the agreed program for 2026-06-05.
- Added Opening, To Be Defined slot, two pauses, IA & software delivery roundtable, and lunch; updated AI Clone duration from 45 to 30.

## Test plan
- [ ] Verify the schedule renders correctly on the Rouen 2026 event page
- [ ] Confirm the workshop (Salle Les Quais) still appears — \`startTime\` intentionally omitted, will be added once known

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated event schedule with explicit start times for all sessions.
  * Enhanced venue details with specific location names.
  * Added new sessions including a roundtable discussion, lunch break, and information blocks.
  * Reorganized session timing and duration for improved event flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->