### PR TITLE
feat(news): add Rouen 2026 pitch article + reusable EventCardBySlug

### DIFF
--- a/src/components/EventCardBySlug/index.astro
+++ b/src/components/EventCardBySlug/index.astro
@@ -1,0 +1,27 @@
+---
+import EventCard from "@/components/EventCard/index.astro";
+import TiltedCard from "@/components/TiltedCard";
+import { eventWithComputed } from "@/lib/events";
+import { getEntry } from "astro:content";
+
+interface Props {
+  slug: string;
+  class?: string;
+}
+
+const { slug, class: className } = Astro.props;
+
+const event = await getEntry("events", slug);
+
+if (!event) {
+  throw new Error(`EventCardBySlug: event "${slug}" not found`);
+}
+
+const computed = await eventWithComputed(event);
+---
+
+<div class:list={["not-prose my-6", className]}>
+  <TiltedCard client:visible scaleOnHover={1}>
+    <EventCard event={computed} />
+  </TiltedCard>
+</div>

--- a/src/content/news/2026-05-06-why-you-should-come-to-fork-it-rouen-2026/index.mdx
+++ b/src/content/news/2026-05-06-why-you-should-come-to-fork-it-rouen-2026/index.mdx
@@ -1,0 +1,71 @@
+---
+title: "Why You Should Come to Fork It! Rouen 2026 (and How to Convince Your Boss)"
+date: 2026-05-06
+excerpt: >
+  An honest take on why developer conferences matter (and a copy-paste pitch
+  to send your manager).
+state: published
+authors:
+  - yoann-fleury
+tags:
+  - conference
+  - community
+  - rouen
+---
+
+import EventCardBySlug from "@/components/EventCardBySlug/index.astro"
+
+Let me be honest with you.
+
+Every time I come back from a tech conference (and I have done a lot), something shifts. I open my laptop on Monday and I'm not the same developer I was on Friday. I want to test things. I want to read that doc I've been putting off for months. I want to ship the side project I told myself I'd start in 2024 (or 2014, but then I remember I'm old).
+
+That's the part nobody tells you. Conferences aren't really about the talks. They're about what happens to you *because* of the talks.
+
+## The talks are great. The corridors are better.
+
+Here's what I've learned from organizing Fork It! events: the speakers you admire on stage are not rock stars. They're regular people who happened to spend three months obsessing over a problem and decided to write a talk about it. You can walk up to them after their slot and ask them anything. Most of the time, *they'll* be the ones thanking *you* for the conversation.
+
+Same goes for the developer next to you in the coffee line. They're working on something fascinating. You just don't know it yet.
+
+My only honest disappointment in conferences? I never have enough time to talk to everyone. Come ready for that.
+
+## June 5, 2026. Rouen. One full day.
+
+Fork It! Rouen 2026 happens at [Le Village By CA](https://levillagebyca.com/), in the heart of Rouen. One full day to learn, practice, and exchange with developers who actually build real products.
+
+No fluff. No hype. Just real people sharing what they've shipped, what they've broken, and what they've learned along the way. We call it *"training human beings, not machines"* — and we mean it.
+
+<EventCardBySlug slug="2026-france-rouen" />
+
+## "But I don't dare ask my boss."
+
+This is the single most common reason I hear for not coming. So let me make it easier.
+
+Here's what a conference actually does for the company that sends you:
+
+- **You come back with new ideas.** Real ones. The kind that turn into PRs, refactors, and "hey, I think we should try this" Slack messages.
+- **You make connections.** Hiring is hard. Knowing twenty engineers in your stack is a competitive advantage for your whole team.
+- **You stay current.** The cost of a senior engineer quietly falling behind the ecosystem is much higher than one ticket and one day off.
+- **You come back energized.** Hard to put on a spreadsheet. Every manager who's seen it knows what it's worth.
+
+Copy this and send it to your manager:
+
+> Hi [Manager], I'd like to attend Fork It! Rouen 2026 on June 5. It's a one-day developer conference focused on real-world experience sharing, not vendor pitches. I'd come back with concrete takeaways for [project/team] and write up a short summary for everyone. The cost is [ticket + travel]. Can we make this work?
+
+That's the whole pitch. If they say no, ask why (most of the time there's room to negotiate).
+
+## Make a weekend of it.
+ 
+Rouen is worth more than a Friday. Time it right, and June 5–7 is one of the best weekends of the year to be in town:
+ 
+- **[Festival L'Art Scène](https://festival-lartscene.vercel.app/)** (June 6–7) — 120+ artists, 13 live concerts and a graffiti jam, all inside a working industrial museum. Pay-what-you-want, suggested €10.
+- **[Cathédrale de Lumière](https://www.metropole-rouen-normandie.fr/festivals-et-manifestations/cathedrale-de-lumiere)** (Friday and Saturday, 11pm) — immersive light projections on the façade of the gothic cathedral. Free, outdoor, the kind of thing you talk about months later.
+- **[Festival Rush](https://rush.le106.com/)** (June 4–13) — free open-air concerts across the metropolitan area. Tamikrest plays Friday, Yuri Buenaventura on Saturday.
+
+Bring a partner. Bring your laptop. Bring nothing. Just stay.
+
+## See you in Rouen.
+
+The lineup is locked, the venue is set, and there are still tickets left. One month to go.
+
+**[Grab your ticket for Fork It! Rouen 2026 →](/events/2026-france-rouen)**

--- a/src/pages/news/article/[id]/index.astro
+++ b/src/pages/news/article/[id]/index.astro
@@ -16,6 +16,7 @@ import { Schema } from "astro-seo-schema";
 import { experimental_AstroContainer } from "astro/container";
 import { loadRenderers } from "astro:container";
 import { getContainerRenderer as mdxContainerRenderer } from "@astrojs/mdx";
+import { getContainerRenderer as reactContainerRenderer } from "@astrojs/react";
 import dayjs from "dayjs";
 import { getEntry } from "astro:content";
 import { ShareButton } from "@/components/ShareButton";
@@ -60,7 +61,10 @@ const relatedArticles = allArticles
   )
   .slice(0, 3);
 
-const renderers = await loadRenderers([mdxContainerRenderer()]);
+const renderers = await loadRenderers([
+  mdxContainerRenderer(),
+  reactContainerRenderer(),
+]);
 const container = await experimental_AstroContainer.create({ renderers });
 const articleBody = (await container.renderToString(Content))
   // strip html tags

--- a/src/pages/news/article/[id]/index.astro
+++ b/src/pages/news/article/[id]/index.astro
@@ -13,10 +13,7 @@ import { render } from "astro:content";
 import JoinTheCommunity from "@/components/JoinTheCommunity/index.astro";
 import SEO from "@/components/SEO/index.astro";
 import { Schema } from "astro-seo-schema";
-import { experimental_AstroContainer } from "astro/container";
-import { loadRenderers } from "astro:container";
-import { getContainerRenderer as mdxContainerRenderer } from "@astrojs/mdx";
-import { getContainerRenderer as reactContainerRenderer } from "@astrojs/react";
+import { mdxToPlainText } from "@/lib/markdown-clean";
 import dayjs from "dayjs";
 import { getEntry } from "astro:content";
 import { ShareButton } from "@/components/ShareButton";
@@ -61,16 +58,8 @@ const relatedArticles = allArticles
   )
   .slice(0, 3);
 
-const renderers = await loadRenderers([
-  mdxContainerRenderer(),
-  reactContainerRenderer(),
-]);
-const container = await experimental_AstroContainer.create({ renderers });
-const articleBody = (await container.renderToString(Content))
-  // strip html tags
-  .replace(/<[^>]*>/g, "")
-  .trim();
-const wordCount = articleBody.split(" ").length;
+const articleBody = (await mdxToPlainText(article.body ?? "")).text.trim();
+const wordCount = articleBody.split(/\s+/).filter(Boolean).length;
 const authors = await Promise.all(
   (article.data.authors ?? []).map(async (author) => await getEntry(author)),
 );


### PR DESCRIPTION
## Summary
- New blog post pitching Fork It! Rouen 2026 with a copy-paste manager ask and a weekend-in-Rouen guide
- New reusable \`EventCardBySlug\` Astro wrapper so MDX articles can embed the interactive event card by slug (resolves the event entry + \`eventWithComputed\` internally, mirroring the \`PersonQuote\` pattern)
- News article page now loads the React container renderer alongside MDX so embedded React components (TiltedCard, react-icons) render correctly when computing the article body for JSON-LD

## Test plan
- [ ] Visit \`/news/article/2026-05-06-why-you-should-come-to-fork-it-rouen-2026\` and verify the embedded EventCard renders with the tilt/hover effect
- [ ] Confirm the article meta (read time / wordCount) still works
- [ ] Spot-check existing articles still render (e.g. \`10-years-of-api-platform\` with PersonQuote)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable event card component that can be embedded by event identifier and displays events with interactive visual wrapper.
  * Published new article: "Why You Should Come to Fork It! Rouen 2026" with event details and ticket call-to-action.

* **Refactor**
  * Improved article text extraction and word-count calculation by converting MDX content to trimmed plain text for more reliable metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->