### PR TITLE
feat(rouen-2026): swap Abeba Ngwe and Nisrine Hamdouni talks

### DIFF
--- a/src/content/events/2026-france-rouen/index.mdx
+++ b/src/content/events/2026-france-rouen/index.mdx
@@ -97,48 +97,48 @@ schedule:
       startTime: 2026-06-05T10:50:00.000Z
       duration: 20
     - type: conference
-      slug: my-toxic-relationship-with-ai
+      slug: je-me-marie-dans-un-mois-patcher-ma-wedding-planner-en-prod
       startTime: 2026-06-05T11:10:00.000Z
-      duration: 45
+      duration: 15
       location: Auditorium Normandie - Seine
     - type: roundtable
       name: To Be Defined
-      startTime: 2026-06-05T12:00:00.000Z
+      startTime: 2026-06-05T11:30:00.000Z
       duration: 45
       location: Auditorium Normandie - Seine
     - type: lunch
       name: Lunch
-      startTime: 2026-06-05T12:50:00.000Z
+      startTime: 2026-06-05T12:20:00.000Z
       duration: 80
     - type: keynote
       slug: keynote-quentin-adam-rouen-2026
       period: afternoon
-      startTime: 2026-06-05T14:10:00.000Z
+      startTime: 2026-06-05T13:40:00.000Z
       duration: 30
       location: Auditorium Normandie - Seine
     - type: conference
       slug: my-ai-clone-attended-conferences-while-i-flew-planes
-      startTime: 2026-06-05T14:45:00.000Z
+      startTime: 2026-06-05T14:15:00.000Z
       duration: 30
       location: Auditorium Normandie - Seine
     - type: conference
       slug: plain-pattern-language-une-book-review-sur-lorigine-des-design-patterns
-      startTime: 2026-06-05T15:20:00.000Z
+      startTime: 2026-06-05T14:50:00.000Z
       duration: 45
       location: Auditorium Normandie - Seine
     - type: info
       name: Pause
-      startTime: 2026-06-05T16:10:00.000Z
+      startTime: 2026-06-05T15:40:00.000Z
       duration: 20
     - type: conference
       slug: bon-cest-bien-joli-vos-technos-de-hipster-mais-moi-je-fais-de-la-prod
-      startTime: 2026-06-05T16:30:00.000Z
+      startTime: 2026-06-05T16:00:00.000Z
       duration: 45
       location: Auditorium Normandie - Seine
     - type: conference
-      slug: je-me-marie-dans-un-mois-patcher-ma-wedding-planner-en-prod
-      startTime: 2026-06-05T17:20:00.000Z
-      duration: 15
+      slug: my-toxic-relationship-with-ai
+      startTime: 2026-06-05T16:50:00.000Z
+      duration: 45
       location: Auditorium Normandie - Seine
     - type: keynote
       slug: mon-apple-2-a-moi-sur-breadboard


### PR DESCRIPTION
## Summary

- Swaps the talks of Abeba Ngwe (`my-toxic-relationship-with-ai`, 45 min) and Nisrine Hamdouni (`je-me-marie-dans-un-mois`, 15 min) in the Rouen 2026 schedule.
- Shifts all items from the roundtable onward 30 minutes earlier to compensate for the shorter morning talk, keeping the same end time (18:10).
- Closing keynote remains at 17:40 as originally planned.

## Test plan

- [ ] Verify the Rouen 2026 schedule page displays correctly
- [ ] Check no time overlaps between talks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Rouen 2026 event schedule with revised talk timings and reordered sessions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Fork-It-Community/forkit.community/pull/814)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->