### PR TITLE
fix: update Xavier workshop start time and duration

### DIFF
--- a/src/content/events/2026-france-rouen/index.mdx
+++ b/src/content/events/2026-france-rouen/index.mdx
@@ -149,8 +149,9 @@ schedule:
       location: Auditorium Normandie - Seine
     - type: workshop
       slug: construisez-votre-propre-micro-service-en-construisant-votre-propre-os
+      startTime: 2026-06-05T16:00:00.000Z
       location: Salle Les Quais
-      duration: 120
+      duration: 90
 subPages:
   - 2026-france-rouen/pages/informations
   - 2026-france-rouen/pages/weekend


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the workshop schedule for the 2026 Rouen event with an adjusted start time and reduced duration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Fork-It-Community/forkit.community/pull/823)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->