### PR TITLE
feat: add alternate markdown links for content

### DIFF
--- a/src/layouts/EventLayout.astro
+++ b/src/layouts/EventLayout.astro
@@ -26,6 +26,9 @@ const navItems = await getEventNavItems(event.id);
 
 const url = new URL(Astro.url.pathname, Astro.site);
 const title = `${event.data._computed.name}, ${getEventDisplayType(event.data.type)}`;
+const markdownHref = lunalink(ROUTES.events[":id.html.md"].__path, {
+  id: event.id,
+});
 ---
 
 <RootLayout>
@@ -36,6 +39,13 @@ const title = `${event.data._computed.name}, ${getEventDisplayType(event.data.ty
     description={event.data.excerpt ?? ""}
     url={url}
     image={ogImage.toString()}
+  />
+  <link
+    slot="seo"
+    rel="alternate"
+    type="text/markdown"
+    title="Markdown version"
+    href={markdownHref}
   />
   {
     !!event?.data.image?.media && (

--- a/src/pages/news/article/[id]/index.astro
+++ b/src/pages/news/article/[id]/index.astro
@@ -73,6 +73,15 @@ const authors = await Promise.all(
     url={url}
     image={ogImage.toString()}
   />
+  <link
+    slot="seo"
+    rel="alternate"
+    type="text/markdown"
+    title="Markdown version"
+    href={lunalink(ROUTES.news.article[":id.html.md"].__path, {
+      id: article.id,
+    })}
+  />
   <Schema
     slot="ld+json"
     item={{

--- a/src/pages/people/[id]/index.astro
+++ b/src/pages/people/[id]/index.astro
@@ -55,6 +55,13 @@ const personAchievements = getPersonAchievements(person);
   />
 
   <SEO slot="seo" title={person.data.name} image={ogImage.toString()} />
+  <link
+    slot="seo"
+    rel="alternate"
+    type="text/markdown"
+    title="Markdown version"
+    href={lunalink(ROUTES.people[":id.html.md"].__path, { id: person.id })}
+  />
   <div
     class="my-16 flex h-full flex-1 flex-col justify-between gap-32 md:my-16"
   >

--- a/src/pages/podcasts/[id]/episodes/[episode]/index.astro
+++ b/src/pages/podcasts/[id]/episodes/[episode]/index.astro
@@ -88,6 +88,16 @@ const url = new URL(Astro.url.pathname, Astro.site);
     description={episode.data.description ?? ""}
     image={ogImage.toString()}
   />
+  <link
+    slot="seo"
+    rel="alternate"
+    type="text/markdown"
+    title="Markdown version"
+    href={lunalink(
+      ROUTES.podcasts[":id"].episodes[":episodes.html.md"].__path,
+      { id: show.id, episodes: number ?? "" },
+    )}
+  />
   <Schema
     slot="ld+json"
     item={{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added alternate markdown versions as discoverable SEO links across events, news articles, people profiles, and podcast episodes to enhance content accessibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Fork-It-Community/forkit.community/pull/834?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->