### PR TITLE
feat: add doors open in schedule rouen 2026

### DIFF
--- a/src/content/events/2026-france-rouen/index.mdx
+++ b/src/content/events/2026-france-rouen/index.mdx
@@ -76,6 +76,9 @@ schedule:
   status: not-final
   items:
     - type: info
+      name: Doors Open
+      startTime: 2026-06-05T08:00:00.000Z
+    - type: info
       name: Opening
       startTime: 2026-06-05T09:00:00.000Z
       duration: 15


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Events**
  * Added a "Doors Open" schedule entry for the Rouen, France 2026 event.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->