### PR TITLE
feat: add after event photos link to rouen 2026

### DIFF
--- a/src/content/events/2026-france-rouen/index.mdx
+++ b/src/content/events/2026-france-rouen/index.mdx
@@ -178,6 +178,9 @@ subPages:
   - 2026-france-rouen/pages/weekend
 feedback:
   link: https://openfeedback.io/2026-france-rouen
+afterEventContent:
+  photos:
+    href: https://photos.app.goo.gl/2K9k8wtcLxG4iPPQ8
 ---
 
 import { buttonVariants } from '@/components/ui/button'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Added photo album link to the 2026 France Rouen event page, enabling users to view event photos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->