### PR TITLE
feat: add VOD playlists to KL 2025, Hanoi 2026, and Tunis 2026 events

### DIFF
--- a/src/content/events/2025-malaysia-kuala-lumpur/index.mdx
+++ b/src/content/events/2025-malaysia-kuala-lumpur/index.mdx
@@ -167,6 +167,8 @@ marketing:
     - title: Portrait Video Save The Date
       href: https://drive.google.com/file/d/1ntSTQeeD7e_rLuoQvqIdXCTw3uGGTkIM/view?usp=drive_link
 afterEventContent:
+  vods:
+    href: https://www.youtube.com/playlist?list=PLnfCgE11xujs1T4_7rN8HBZH4MYk_FOSJ
   photos:
     href: https://photos.app.goo.gl/qLpD5z63vEMnPodb8
     sources:

--- a/src/content/events/2026-tunisia-tunis/index.mdx
+++ b/src/content/events/2026-tunisia-tunis/index.mdx
@@ -32,6 +32,8 @@ sponsoringLevels:
 eventStatus: EventScheduled
 attendanceMode: OfflineEventAttendanceMode
 afterEventContent:
+  vods:
+    href: https://www.youtube.com/playlist?list=PLnfCgE11xujuLoDFmFnAei5wgH-Un-tWC
   photos:
     href: https://photos.app.goo.gl/C9ckYQUYWNPdVZxU7
     sources:

--- a/src/content/events/2026-vietnam-hanoi/index.mdx
+++ b/src/content/events/2026-vietnam-hanoi/index.mdx
@@ -166,6 +166,8 @@ lumaEventId: "evt-crfgFF29uvJK6X7"
 marketing:
   withFlags: true
 afterEventContent:
+  vods:
+    href: https://www.youtube.com/playlist?list=PLnfCgE11xujv3P40-qSKu5FE_fXyR2hqB
   photos:
     href: https://photos.app.goo.gl/mmSU35raSWFFWvzx9
     sources:


### PR DESCRIPTION
Add YouTube VOD playlist links to three full-day events that were missing them.

- Fork it! Kuala Lumpur 2025 → [PLnfCgE11xujs1T4_7rN8HBZH4MYk_FOSJ](https://www.youtube.com/playlist?list=PLnfCgE11xujs1T4_7rN8HBZH4MYk_FOSJ)
- Fork it! Hanoi 2026 → [PLnfCgE11xujv3P40-qSKu5FE_fXyR2hqB](https://www.youtube.com/playlist?list=PLnfCgE11xujv3P40-qSKu5FE_fXyR2hqB)
- Fork it! Tunis 2026 → [PLnfCgE11xujuLoDFmFnAei5wgH-Un-tWC](https://www.youtube.com/playlist?list=PLnfCgE11xujuLoDFmFnAei5wgH-Un-tWC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Post-event video recordings now available for three events: Kuala Lumpur 2025, Tunisia/Tunis 2026, and Vietnam/Hanoi 2026. Each event page now includes a link to its respective video on demand (VOD) playlist, allowing attendees to revisit sessions and catch content they may have missed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->