### PR TITLE
fix: allow img.youtube.com for VOD thumbnails

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -35,6 +35,10 @@ const adapter =
 export default defineConfig({
   site: getSiteUrl(),
 
+  image: {
+    remotePatterns: [{ hostname: "img.youtube.com" }],
+  },
+
   i18n: {
     locales: ["en", "fr"],
     defaultLocale: "en",


### PR DESCRIPTION
## Summary

- Adds `img.youtube.com` to Astro's `image.remotePatterns` so the Vercel image service can serve YouTube thumbnails
- The Vercel image service was enabled in #870 to fix speaker/sponsor images, but it blocks undeclared remote domains by default, which broke VOD thumbnail display on the video listing page

## Test plan

- [ ] Check the VOD listing page — thumbnails should display correctly in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for loading images from YouTube’s image domain, allowing remote image content to display properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->