### PR TITLE
feat: add missing VODs for Tunis 2026 and Rouen 2026

### DIFF
--- a/src/content/events/2026-france-rouen/index.mdx
+++ b/src/content/events/2026-france-rouen/index.mdx
@@ -179,6 +179,8 @@ subPages:
 feedback:
   link: https://openfeedback.io/2026-france-rouen
 afterEventContent:
+  vods:
+    href: https://www.youtube.com/playlist?list=PLUGFZ3s2tgJ8
   afterMovie:
     href: https://www.youtube.com/watch?v=u2BsrHmKyic
     thumbnail:

--- a/src/content/talks/codons-un-maitre-du-jeu-de-role-multi-agents-avec-strands-agents.mdx
+++ b/src/content/talks/codons-un-maitre-du-jeu-de-role-multi-agents-avec-strands-agents.mdx
@@ -5,6 +5,9 @@ speakers:
   - id: tiffany-souterre
 language: french
 contentLanguage: french
+vod:
+  type: youtube
+  youtubeId: g9U8_AYr9PU
 ---
 
 Le maitre du jeu (MJ) joue un role central dans les jeux de role: il cree les histoires des joueurs, incarne les PNJ et s'assure que les regles soient respectees. L'IA peut etre un formidable allie pour les MJ, en les aidant a verifier les regles, improviser des scenarios et creer du contenu a la volee. Dans ce talk/live coding, nous coderons ensemble un maitre du jeu IA multi-agents a l'aide du SDK open source Strands Agents. Nous mettrons en place des agents specialises pour differentes responsabilites du MJ et verrons comment ils collaborent via le protocole Agent-to-Agent (A2A) et des integrations d'outils grace au protocole MCP.

--- a/src/content/talks/keynote-ivan-dalmet-rouen-2026.mdx
+++ b/src/content/talks/keynote-ivan-dalmet-rouen-2026.mdx
@@ -4,6 +4,9 @@ speakers:
   - id: ivan-dalmet
 language: english
 contentLanguage: english
+vod:
+  type: youtube
+  youtubeId: 04oFcjjERY0
 feedback:
   link: https://openfeedback.io/2026-france-rouen/0/B7yqiY1fG0jvjmBlNos1
 ---

--- a/src/content/talks/le-futur-de-lia-est-dans-les-navigateurs.mdx
+++ b/src/content/talks/le-futur-de-lia-est-dans-les-navigateurs.mdx
@@ -4,6 +4,9 @@ speakers:
   - id: yassine-benabbas
 language: french
 contentLanguage: french
+vod:
+  type: youtube
+  youtubeId: TZu_XN9Jc4s
 ---
 
 Avec l'essor de l'IA generative (GenAI), de plus en plus d'applications tirent parti de fonctionnalites liees a l'IA, comme la traduction automatique ou la transcription vocale. Cependant, on peut croire que leur mise en place necessite systematiquement un backend dedie, ce qui peut complexifier le developpement et la maintenance des applications. Ceci ne sera bientot plus le cas grace aux avancees recentes dans les navigateurs web.

--- a/src/content/talks/leveraging-the-expressionlanguage-component-let-your-users-be-creative.mdx
+++ b/src/content/talks/leveraging-the-expressionlanguage-component-let-your-users-be-creative.mdx
@@ -4,6 +4,9 @@ speakers:
   - id: mathias-arlaud
 language: english
 contentLanguage: english
+vod:
+  type: youtube
+  youtubeId: 0mWkjQQQ7nM
 ---
 
 The ExpressionLanguage component is an old but very useful component. Many well known projects are using it (OroCRM, API Platform, Sylius, Symfony itself, ...).


### PR DESCRIPTION
Adds missing VOD YouTube IDs for the Fork it! Tunis 2026 and Rouen 2026 full-day events.

For Tunis 2026, adds VODs to 3 talks that were missing them (3 others already had theirs): Leveraging the ExpressionLanguage component, Codons un maître du jeu multi-agents, and Le futur de l'IA dans les navigateurs. For Rouen 2026, adds the VOD playlist link to the event and the YouTube ID for Ivan Dalmet's keynote (the only talk uploaded so far).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added video-on-demand links for several event and talk pages, making recorded content easier to access.
  * Included a YouTube playlist for one event’s post-event resources.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->