### PR TITLE
feat: add community vibes section to home page (#546)

### DIFF
--- a/src/components/CommunityVibes/index.astro
+++ b/src/components/CommunityVibes/index.astro
@@ -1,0 +1,77 @@
+---
+import { Image } from "astro:assets";
+import { COMMUNITY_VIBES_IMAGES } from "@/content/communityVibes";
+
+const images = COMMUNITY_VIBES_IMAGES;
+---
+
+<div class="relative flex flex-col gap-8 py-24">
+  <div class="mx-auto w-full max-w-screen-md px-6">
+    <div class="text-center">
+      <h2
+        class="font-heading text-2xl font-medium uppercase tracking-widest text-white md:text-3xl"
+      >
+        Community vibes
+      </h2>
+      <p class="text-balance text-base tracking-wide opacity-60">
+        Snapshots from our events and meetups around the world
+      </p>
+    </div>
+  </div>
+  <div class="grid w-full grid-cols-3 gap-1 md:grid-cols-5">
+    <div class="col-span-2 row-span-2 aspect-square bg-background">
+      <Image
+        src={images[0].src}
+        alt={images[0].alt}
+        width={1200}
+        height={1200}
+        class="h-full w-full object-cover"
+      />
+    </div>
+    <div class="aspect-square bg-background">
+      <Image
+        src={images[1].src}
+        alt={images[1].alt}
+        width={600}
+        height={600}
+        class="h-full w-full object-cover"
+      />
+    </div>
+    <div class="aspect-square bg-background">
+      <Image
+        src={images[2].src}
+        alt={images[2].alt}
+        width={600}
+        height={600}
+        class="h-full w-full object-cover"
+      />
+    </div>
+    <div class="bg-background max-md:aspect-square md:row-span-2">
+      <Image
+        src={images[3].src}
+        alt={images[3].alt}
+        width={1200}
+        height={1200}
+        class="h-full w-full object-cover"
+      />
+    </div>
+    <div class="aspect-square bg-background">
+      <Image
+        src={images[4].src}
+        alt={images[4].alt}
+        width={600}
+        height={600}
+        class="h-full w-full object-cover"
+      />
+    </div>
+    <div class="aspect-square bg-background">
+      <Image
+        src={images[5].src}
+        alt={images[5].alt}
+        width={600}
+        height={600}
+        class="h-full w-full object-cover"
+      />
+    </div>
+  </div>
+</div>

--- a/src/content/communityVibes.ts
+++ b/src/content/communityVibes.ts
@@ -1,0 +1,21 @@
+import franceImage from "@/content/countries/france/images/image-1.jpg";
+import tunisiaImage from "@/content/countries/tunisia/images/image-2.jpg";
+import vietnamImage from "@/content/countries/vietnam/images/image-2.jpeg";
+import franceImage2 from "@/content/countries/france/images/image-4.jpg";
+import kualaImage from "@/content/events/2025-malaysia-kuala-lumpur/images/image3.jpg";
+import forkids from "@/content/for-kids-events/2025-france-rouen-2/images/image2.jpg";
+
+// A curated selection of pictures from events and meetups across the
+// worldwide Fork it! Community. Displayed in the "Community vibes" section
+// on the home page.
+export const COMMUNITY_VIBES_IMAGES = [
+  { src: franceImage, alt: "Fork it! community event in France" },
+  { src: tunisiaImage, alt: "Fork it! community event in Tunisia" },
+  { src: vietnamImage, alt: "Fork it! community event in Vietnam" },
+  { src: franceImage2, alt: "Fork it! community meetup in France" },
+  {
+    src: kualaImage,
+    alt: "Fork it! community event in Kuala Lumpur, Malaysia",
+  },
+  { src: forkids, alt: "Fork it! For Kids event in Rouen, France" },
+] as const;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -225,37 +225,6 @@ const forKidsAfterMovie = (
     </div>
   </div>
 
-  <!-- ABOUT (What is Fork it! Community) -->
-  <div class="flex flex-col gap-32">
-    <div class="relative overflow-hidden py-16 sm:py-40">
-      <Image
-        alt=""
-        class="absolute inset-0 h-full w-full -scale-x-100 object-cover opacity-35 mix-blend-color-dodge grayscale md:opacity-100"
-        src={aboutBackground}
-        width={1200}
-      />
-      <div
-        class="absolute inset-0 bg-gradient-to-br from-black/70 via-black/60 to-black/0"
-      >
-      </div>
-      <div
-        class="absolute inset-0 h-full w-full"
-        style={{
-          backdropFilter: "blur(64px)",
-          maskImage: "linear-gradient(90deg, black 30%, transparent 70%)",
-        }}
-      >
-      </div>
-      <About
-        afterMovie={afterMovie}
-        href={lunalink(ROUTES.about.__path, {})}
-        title={`What is Fork${"\u00A0"}it! Community?`}
-        description="Fork it! is a global tech community where real people share honest feedback, real-life experiences, and authentic stories."
-        buttonText="About Fork it!"
-      />
-    </div>
-  </div>
-
   <div class="flex flex-col gap-8 py-12">
     <JoinTheCommunity />
     <JoinNewsletter />
@@ -377,8 +346,38 @@ const forKidsAfterMovie = (
     </div>
   </div>
 
-  <!-- FORK IT FOR KIDS -->
+  <!-- COMMUNITY VIBES -->
+  <CommunityVibes />
+
+  <!-- ABOUT -->
   <div class="flex flex-col gap-32">
+    <div class="relative overflow-hidden py-16 sm:py-40">
+      <Image
+        alt=""
+        class="absolute inset-0 h-full w-full -scale-x-100 object-cover opacity-35 mix-blend-color-dodge grayscale md:opacity-100"
+        src={aboutBackground}
+        width={1200}
+      />
+      <div
+        class="absolute inset-0 bg-gradient-to-br from-black/70 via-black/60 to-black/0"
+      >
+      </div>
+      <div
+        class="absolute inset-0 h-full w-full"
+        style={{
+          backdropFilter: "blur(64px)",
+          maskImage: "linear-gradient(90deg, black 30%, transparent 70%)",
+        }}
+      >
+      </div>
+      <About
+        afterMovie={afterMovie}
+        href={lunalink(ROUTES.about.__path, {})}
+        title={`What is Fork${"\u00A0"}it! Community?`}
+        description="Fork it! is a global tech community where real people share honest feedback, real-life experiences, and authentic stories."
+        buttonText="About Fork it!"
+      />
+    </div>
     <About
       afterMovie={forKidsAfterMovie}
       href={lunalink(ROUTES.fr.events["for-kids"].__path, {})}
@@ -388,9 +387,6 @@ const forKidsAfterMovie = (
       reverse
     />
   </div>
-
-  <!-- COMMUNITY VIBES -->
-  <CommunityVibes />
 
   <!-- PARTNERS -->
   {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -26,6 +26,7 @@ import GlobalCFP from "@/components/GlobalCFP/index.astro";
 import ArticleSlider from "@/components/ArticleSlider/index.astro";
 import VodSlider from "@/components/VodSlider/index.astro";
 import About from "@/components/About/index.astro";
+import CommunityVibes from "@/components/CommunityVibes/index.astro";
 
 import { getUpcomingEvents } from "@/lib/events";
 import SEO from "@/components/SEO/index.astro";
@@ -224,6 +225,37 @@ const forKidsAfterMovie = (
     </div>
   </div>
 
+  <!-- ABOUT (What is Fork it! Community) -->
+  <div class="flex flex-col gap-32">
+    <div class="relative overflow-hidden py-16 sm:py-40">
+      <Image
+        alt=""
+        class="absolute inset-0 h-full w-full -scale-x-100 object-cover opacity-35 mix-blend-color-dodge grayscale md:opacity-100"
+        src={aboutBackground}
+        width={1200}
+      />
+      <div
+        class="absolute inset-0 bg-gradient-to-br from-black/70 via-black/60 to-black/0"
+      >
+      </div>
+      <div
+        class="absolute inset-0 h-full w-full"
+        style={{
+          backdropFilter: "blur(64px)",
+          maskImage: "linear-gradient(90deg, black 30%, transparent 70%)",
+        }}
+      >
+      </div>
+      <About
+        afterMovie={afterMovie}
+        href={lunalink(ROUTES.about.__path, {})}
+        title={`What is Fork${"\u00A0"}it! Community?`}
+        description="Fork it! is a global tech community where real people share honest feedback, real-life experiences, and authentic stories."
+        buttonText="About Fork it!"
+      />
+    </div>
+  </div>
+
   <div class="flex flex-col gap-8 py-12">
     <JoinTheCommunity />
     <JoinNewsletter />
@@ -345,35 +377,8 @@ const forKidsAfterMovie = (
     </div>
   </div>
 
-  <!-- ABOUT -->
+  <!-- FORK IT FOR KIDS -->
   <div class="flex flex-col gap-32">
-    <div class="relative overflow-hidden py-16 sm:py-40">
-      <Image
-        alt=""
-        class="absolute inset-0 h-full w-full -scale-x-100 object-cover opacity-35 mix-blend-color-dodge grayscale md:opacity-100"
-        src={aboutBackground}
-        width={1200}
-      />
-      <div
-        class="absolute inset-0 bg-gradient-to-br from-black/70 via-black/60 to-black/0"
-      >
-      </div>
-      <div
-        class="absolute inset-0 h-full w-full"
-        style={{
-          backdropFilter: "blur(64px)",
-          maskImage: "linear-gradient(90deg, black 30%, transparent 70%)",
-        }}
-      >
-      </div>
-      <About
-        afterMovie={afterMovie}
-        href={lunalink(ROUTES.about.__path, {})}
-        title={`What is Fork${"\u00A0"}it! Community?`}
-        description="Fork it! is a global tech community where real people share honest feedback, real-life experiences, and authentic stories."
-        buttonText="About Fork it!"
-      />
-    </div>
     <About
       afterMovie={forKidsAfterMovie}
       href={lunalink(ROUTES.fr.events["for-kids"].__path, {})}
@@ -383,6 +388,9 @@ const forKidsAfterMovie = (
       reverse
     />
   </div>
+
+  <!-- COMMUNITY VIBES -->
+  <CommunityVibes />
 
   <!-- PARTNERS -->
   {


### PR DESCRIPTION
## Goal

Closes #546 — Add a "Community vibes" section on the home page, inspired by the event vibes section, with photos from events and meetups in different countries.

## What's included

- **New `CommunityVibes` component** (`src/components/CommunityVibes/index.astro`) reusing the event-vibes masonry grid layout.
- **Curated image config** (`src/content/communityVibes.ts`) with photos from France, Tunisia, Vietnam, Malaysia (Kuala Lumpur) and Fork it! For Kids (Rouen). Each image is paired with a descriptive `alt` for accessibility + image SEO.
- **Home page section reordering** to: What is Fork it!, newsletter, news, podcasts, VODs, CFP, Fork it! For Kids, community vibes, sponsors. No content was modified — only order.

## SEO / a11y notes

- Heading hierarchy preserved (single `<h1>`, proper `<h2>` sections).
- Community vibes images optimized via Astro `<Image>` (fixed dimensions → no CLS, lazy-loaded below the fold → no LCP impact), each with descriptive alt text.

## Verification

- `astro check`: 0 errors, 0 warnings, 0 hints
- Prettier: all files conform

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Community Vibes” section to the homepage.
  * Showcases six accessible, responsive photos from community events and meetups across multiple locations.
  * Includes descriptive introductory text highlighting community experiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->