### PR TITLE
feat: e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,58 @@
+name: E2E
+
+# Triggered by Vercel's deployment status rather than by the pull request.
+#
+# Two reasons. The preview URL is only known once Vercel has finished, and a
+# `deployment_status` workflow runs in the base repository's context — so it
+# has access to secrets on Dependabot pull requests, which a `pull_request`
+# workflow does not. Gating dependency bumps is the whole point of this suite,
+# so that difference decides the trigger.
+on:
+  deployment_status:
+
+concurrency:
+  group: e2e-${{ github.event.deployment.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    # Preview deployments only, and only once they have actually succeeded.
+    if: >-
+      github.event.deployment_status.state == 'success' &&
+      github.event.deployment.environment == 'Preview'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # The commit that was deployed, not the tip of the branch — the
+          # suite reads vercel.json from the checkout and it has to match
+          # what is actually running at the preview URL.
+          ref: ${{ github.event.deployment.sha }}
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm exec playwright install --with-deps chromium
+
+      - run: pnpm exec playwright test
+        env:
+          E2E_BASE_URL: ${{ github.event.deployment_status.environment_url }}
+          # Preview deployments are protected by default; without this every
+          # request comes back 401 from Vercel's auth wall.
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,7 +25,7 @@ jobs:
       github.event.deployment.environment == 'Preview'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           # The commit that was deployed, not the tip of the branch — the
           # suite reads vercel.json from the checkout and it has to match
@@ -37,14 +37,10 @@ jobs:
           # step needs git auth, so don't leave the token in .git/config.
           persist-credentials: false
 
-      - uses: pnpm/action-setup@v4
-
-      - uses: actions/setup-node@v4
+      - uses: pnpm/setup@v2
         with:
-          node-version: 24
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
+          cache: true
+          runtime: node@24
 
       - run: pnpm exec playwright install --with-deps chromium
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,6 +31,11 @@ jobs:
           # suite reads vercel.json from the checkout and it has to match
           # what is actually running at the preview URL.
           ref: ${{ github.event.deployment.sha }}
+          # This checkout is attacker-influenced: on a pull request the
+          # deployed sha is contributor code, and `pnpm install` runs the
+          # repository's own `prepare` script from it. Nothing after this
+          # step needs git auth, so don't leave the token in .git/config.
+          persist-credentials: false
 
       - uses: pnpm/action-setup@v4
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,7 +41,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,9 @@ pnpm-debug.log*
 .idea/
 
 .vscode/settings.json
+
+# playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/README.md
+++ b/README.md
@@ -92,9 +92,13 @@ request, because the preview URL is only known once Vercel has finished — and
 because a `deployment_status` workflow can read secrets on Dependabot pull
 requests, which is exactly where this suite earns its keep.
 
-It needs one repository secret, `VERCEL_AUTOMATION_BYPASS_SECRET`. Preview
-deployments are protection-enabled by default, and without it every request
-returns 401.
+No secret is needed as things stand: preview deployments on this project are
+publicly reachable. If Deployment Protection is ever switched on, every
+request will start returning 401 — at that point generate a bypass token in
+Vercel (Settings → Deployment Protection → Protection Bypass for Automation)
+and add it as a repository secret named `VERCEL_AUTOMATION_BYPASS_SECRET`.
+The workflow already passes it through and the suite already sends it as a
+header when it is present, so nothing else needs changing.
 
 One consequence worth knowing: because the run is tied to a deployment, it
 reports nothing at all when Vercel does not deploy. If this is ever made a

--- a/README.md
+++ b/README.md
@@ -39,6 +39,68 @@ pnpm run build:node
 pnpm run preview
 ```
 
+## ✅ End-to-end tests
+
+```bash
+pnpm test:e2e
+```
+
+That is the whole thing. It builds the site with the node adapter, serves it
+on port 4329, runs the suite against it, and shuts down. The first run
+downloads Chromium (~150MB); later runs do not. No environment variables and
+no secrets are needed.
+
+To run against something already deployed instead of building locally:
+
+```bash
+E2E_BASE_URL=https://your-preview.vercel.app pnpm test:e2e
+```
+
+`E2E_BASE_URL` is the only switch. When it is set, nothing is built and
+nothing is served — the suite just points at that target.
+
+### What it covers
+
+Eleven specs, deliberately thin. Eight run over plain HTTP with no browser at
+all, which is sound here because the site has no client-side router: following
+a link over HTTP is equivalent to clicking it. The three that do launch a
+browser cover the only things that are not — the search palette, the attendee
+form, and the nav menus, whose links do not exist until their island hydrates.
+
+Assertions are structural — status codes, content types, a non-empty title, a
+floor on rendered text or image size. They never mention actual content, so
+adding an event or a person does not break them. URLs come from the sitemap
+rather than a hard-coded list, so new content is swept automatically and
+drafts are excluded for free.
+
+### Green locally is weaker than green in CI
+
+A local run serves the site through the **node** adapter. CI runs against a
+real **Vercel** preview. Vercel-only behaviour therefore cannot be covered
+locally and is skipped:
+
+- the ~20 redirects in `vercel.json`, which are applied at Vercel's edge
+- ISR, and Vercel's image service
+
+So a local pass means "nothing is broken in the app", not "nothing is broken
+in production". CI is the authority.
+
+### In CI
+
+The workflow is triggered by Vercel's `deployment_status`, not by the pull
+request, because the preview URL is only known once Vercel has finished — and
+because a `deployment_status` workflow can read secrets on Dependabot pull
+requests, which is exactly where this suite earns its keep.
+
+It needs one repository secret, `VERCEL_AUTOMATION_BYPASS_SECRET`. Preview
+deployments are protection-enabled by default, and without it every request
+returns 401.
+
+One consequence worth knowing: because the run is tied to a deployment, it
+reports nothing at all when Vercel does not deploy. If this is ever made a
+required status check, a pull request in that situation cannot be merged
+without an admin bypass.
+
 ## 🚀 Project Structure
 
 Inside the project, you'll see the following folders and files:
@@ -46,6 +108,7 @@ Inside the project, you'll see the following folders and files:
 ```text
 /
 ├── components.json          # Component registry/configuration
+├── e2e/                     # End-to-end tests (Playwright)
 ├── package.json
 ├── public/                  # Static assets (served at site root)
 ├── scripts/                 # Utility scripts for development

--- a/e2e/assets.spec.ts
+++ b/e2e/assets.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "@playwright/test";
+import { binaryProblems, checkBinaries } from "./support/assert";
+import { fetchSitemapPaths } from "./support/sitemap";
+import { newestEvents } from "./support/select";
+
+/**
+ * Generated assets: one endpoint per satori template family.
+ *
+ * Each family is a different template with its own layout and fonts, so a
+ * bumped `satori` or `sharp` can break one and leave the rest working. One
+ * URL per family is the cheapest way to learn which.
+ *
+ * None of these URLs are in the sitemap — they are API routes, not pages — so
+ * the ids are derived from sitemap page paths and the endpoint is built from
+ * them. A missing template answers 500 rather than 404, so a wrong name here
+ * fails loudly rather than passing quietly.
+ */
+
+/** Every asset on this site is JPEG; `.png` is not a supported type. */
+const IMAGE_TYPE = /^image\//;
+
+/** Well under the smallest real asset (~67KB), well over an empty render. */
+const MIN_IMAGE_BYTES = 5_000;
+
+const firstMatch = (paths: string[], pattern: RegExp): string => {
+  const match = paths.find((path) => pattern.test(path));
+  if (!match) throw new Error(`no sitemap path matching ${String(pattern)}`);
+  return match;
+};
+
+test("one generated image per template family renders", async ({ request }) => {
+  const paths = await fetchSitemapPaths(request);
+  const [event] = newestEvents(paths, 1);
+  expect(event, "no event found in the sitemap").toBeTruthy();
+
+  // Partners have no page of their own, so their ids are not in the sitemap.
+  // The event's asset index advertises them, which keeps this derived rather
+  // than pinned to a sponsor who may not be a sponsor next year.
+  const assetsIndex = await (await request.get(`${event}/assets`)).text();
+  const partnerAsset =
+    /\/events\/[^"'\s]+\/partners\/[^"'\s]+\/assets\/large\.jpg/.exec(
+      assetsIndex,
+    )?.[0];
+
+  const targets = [
+    // Event: the OG image, plus one non-OG template as a canary for the ~25
+    // other social templates that share its machinery.
+    `${event}/assets/og-image.jpg`,
+    `${event}/assets/save-the-date.jpg`,
+    `${firstMatch(paths, /^\/people\/[^/]+$/)}/assets/og-image.jpg`,
+    `${firstMatch(paths, /^\/news\/article\/[^/]+$/)}/assets/og-image.jpg`,
+    `${firstMatch(paths, /^\/podcasts\/[^/]+\/episodes\/[^/]+$/)}/assets/og-image.jpg`,
+    `${firstMatch(paths, /^\/events\/locations\/[^/]+$/)}/assets/og-image.jpg`,
+    `${firstMatch(paths, /^\/fr\/events\/for-kids\/[^/]+$/)}/assets/og-image.jpg`,
+    // Talks have no og-image template; `large` is their equivalent.
+    `${firstMatch(paths, /^\/events\/[^/]+\/talks\/[^/]+$/)}/assets/large.jpg`,
+    ...(partnerAsset ? [partnerAsset] : []),
+  ];
+
+  expect(partnerAsset, "no partner asset advertised on the event").toBeTruthy();
+
+  const checks = await checkBinaries(request, targets);
+  expect(
+    binaryProblems(checks, IMAGE_TYPE, MIN_IMAGE_BYTES),
+    "generated images that did not render",
+  ).toEqual([]);
+});

--- a/e2e/attendee.spec.ts
+++ b/e2e/attendee.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test, waitForHydration } from "./support/browser";
+import { fetchSitemapPaths } from "./support/sitemap";
+import { newestEvents } from "./support/select";
+
+/**
+ * The attendee ticket flow: type a name, get a shareable ticket page.
+ *
+ * Entirely client-side — the form does no request and persists nothing, it
+ * just redirects to a URL built from the name — so this is safe to run
+ * against any target, production included.
+ */
+
+const ATTENDEE_NAME = "E2E Test";
+
+test("submitting the attendee form produces a ticket page", async ({
+  page,
+}) => {
+  const paths = await fetchSitemapPaths(page.request);
+  const [event] = newestEvents(paths, 1);
+  expect(event, "no event found in the sitemap").toBeTruthy();
+
+  await page.goto(`${event}/attendee`);
+
+  const nameInput = page.getByPlaceholder("Your name");
+  await waitForHydration(nameInput);
+  await nameInput.fill(ATTENDEE_NAME);
+  await page.getByRole("button", { name: "Generate" }).click();
+
+  await page.waitForURL(
+    `**${event}/attendee/${encodeURIComponent(ATTENDEE_NAME)}`,
+  );
+  await expect(page.getByRole("img").first()).toBeVisible();
+});

--- a/e2e/download.spec.ts
+++ b/e2e/download.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "@playwright/test";
+import { binaryProblems, checkBinaries } from "./support/assert";
+import { fetchSitemapPaths } from "./support/sitemap";
+import { newestEvents } from "./support/select";
+
+/**
+ * The event asset bundle. Worth its own spec rather than folding into the
+ * image sweep: this is the one asset endpoint built on adm-zip rather than
+ * satori, so it breaks for entirely different reasons.
+ *
+ * Size only — parsing the archive would mean adding adm-zip as a test
+ * dependency to learn very little more than "it is not empty".
+ */
+
+const ARCHIVE_TYPE = /zip/;
+const MIN_ARCHIVE_BYTES = 100_000;
+
+test("the event asset bundle downloads", async ({ request }) => {
+  const paths = await fetchSitemapPaths(request);
+  const [event] = newestEvents(paths, 1);
+  expect(event, "no event found in the sitemap").toBeTruthy();
+
+  const checks = await checkBinaries(request, [`${event}/assets/download`]);
+  expect(
+    binaryProblems(checks, ARCHIVE_TYPE, MIN_ARCHIVE_BYTES),
+    "asset bundle",
+  ).toEqual([]);
+});

--- a/e2e/download.spec.ts
+++ b/e2e/download.spec.ts
@@ -1,5 +1,5 @@
+import AdmZip from "adm-zip";
 import { expect, test } from "@playwright/test";
-import { binaryProblems, checkBinaries } from "./support/assert";
 import { fetchSitemapPaths } from "./support/sitemap";
 import { newestEvents } from "./support/select";
 
@@ -8,11 +8,10 @@ import { newestEvents } from "./support/select";
  * image sweep: this is the one asset endpoint built on adm-zip rather than
  * satori, so it breaks for entirely different reasons.
  *
- * Size only — parsing the archive would mean adding adm-zip as a test
- * dependency to learn very little more than "it is not empty".
+ * Fetched once — it is a ~10MB response and the slowest request in the suite
+ * — and every assertion is made against that one body.
  */
 
-const ARCHIVE_TYPE = /zip/;
 const MIN_ARCHIVE_BYTES = 100_000;
 
 test("the event asset bundle downloads", async ({ request }) => {
@@ -20,9 +19,17 @@ test("the event asset bundle downloads", async ({ request }) => {
   const [event] = newestEvents(paths, 1);
   expect(event, "no event found in the sitemap").toBeTruthy();
 
-  const checks = await checkBinaries(request, [`${event}/assets/download`]);
-  expect(
-    binaryProblems(checks, ARCHIVE_TYPE, MIN_ARCHIVE_BYTES),
-    "asset bundle",
-  ).toEqual([]);
+  const response = await request.get(`${event}/assets/download`);
+  expect(response.status(), "asset bundle status").toBe(200);
+  expect(response.headers()["content-type"] ?? "").toMatch(/zip/);
+
+  const body = await response.body();
+  expect(body.length, "asset bundle size").toBeGreaterThan(MIN_ARCHIVE_BYTES);
+
+  // adm-zip is what builds this response, so it is also what a bad bump of
+  // adm-zip would break — and it would break it into something with the right
+  // status, the right content-type and roughly the right size. Reading the
+  // entries back is the only assertion here that would notice.
+  const entries = new AdmZip(body).getEntries();
+  expect(entries.length, "entries in the asset bundle").toBeGreaterThan(0);
 });

--- a/e2e/events.spec.ts
+++ b/e2e/events.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "@playwright/test";
+import { checkPages, renderProblems } from "./support/assert";
+import { fetchSitemapPaths } from "./support/sitemap";
+import { descendantsOf, newestEvents } from "./support/select";
+
+/**
+ * Content integrity for events: the collection where a badly authored entry
+ * is most likely to produce a broken page, and where the page is assembled
+ * from the most moving parts.
+ *
+ * Sampled newest-first rather than pinned, so a freshly added event is always
+ * in the sample. Sorting works because slugs are year-prefixed, and drafts
+ * never appear because the sample comes from the sitemap.
+ */
+
+const SAMPLE_SIZE = 5;
+
+test("the newest events and all their sub-pages render", async ({
+  request,
+}) => {
+  const paths = await fetchSitemapPaths(request);
+  const events = newestEvents(paths, SAMPLE_SIZE);
+
+  expect(events.length, "events found in the sitemap").toBe(SAMPLE_SIZE);
+
+  const targets = events.flatMap((event) => [
+    event,
+    ...descendantsOf(paths, event),
+  ]);
+
+  // Guards against the sample silently collapsing to bare index pages if the
+  // sitemap ever stops listing sub-pages.
+  expect(targets.length).toBeGreaterThan(events.length);
+
+  const checks = await checkPages(request, targets);
+  expect(renderProblems(checks), "event pages that did not render").toEqual([]);
+});

--- a/e2e/links.spec.ts
+++ b/e2e/links.spec.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "@playwright/test";
+import { checkPages, statusProblems } from "./support/assert";
+import { internalLinks } from "./support/html";
+import { fetchSitemapPaths } from "./support/sitemap";
+import { newestEvents } from "./support/select";
+
+/**
+ * Link-graph integrity, one level deep from a couple of seed pages.
+ *
+ * This is what "check the navigation works" actually means here. The site has
+ * no client-side router, so following an href over HTTP is equivalent to
+ * clicking it, and this reaches far more links than anyone would click by
+ * hand. The links that are *not* equivalent — the ones that only exist after
+ * hydration — are covered by the browser specs instead.
+ *
+ * Same-origin only. External links are never requested: a sponsor rebranding
+ * their site is not a regression in this repository, and a merge-blocking
+ * check must not depend on third-party uptime.
+ */
+
+test("links reachable from the home page resolve", async ({
+  request,
+  baseURL,
+}) => {
+  const pageUrl = new URL("/", baseURL).toString();
+  const html = await (await request.get("/")).text();
+  const links = internalLinks(html, pageUrl);
+
+  expect(links.length, "internal links found on the home page").toBeGreaterThan(
+    10,
+  );
+
+  const checks = await checkPages(request, links);
+  expect(statusProblems(checks), "broken links on the home page").toEqual([]);
+});
+
+test("links reachable from an event page resolve", async ({
+  request,
+  baseURL,
+}) => {
+  const paths = await fetchSitemapPaths(request);
+  const [event] = newestEvents(paths, 1);
+  expect(event, "no event found in the sitemap").toBeTruthy();
+
+  const pageUrl = new URL(event ?? "/", baseURL).toString();
+  const html = await (await request.get(event ?? "/")).text();
+  const links = internalLinks(html, pageUrl);
+
+  expect(
+    links.length,
+    "internal links found on the event page",
+  ).toBeGreaterThan(5);
+
+  const checks = await checkPages(request, links);
+  expect(statusProblems(checks), "broken links on the event page").toEqual([]);
+});

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test, waitForHydration } from "./support/browser";
+
+/**
+ * The only links on the site that a browser is genuinely needed for.
+ *
+ * Everything else is a plain <a href> in server-rendered HTML, which the
+ * link-graph spec follows over HTTP far more thoroughly than clicking ever
+ * could. These two menus are different: their links do not exist until the
+ * island hydrates and the user opens them, so no crawler can reach them.
+ *
+ * Both viewports live in one spec to keep the suite's size honest. The cost
+ * is that a failure says "nav broke" and you read the trace to learn which.
+ */
+
+const DESKTOP = { width: 1280, height: 800 };
+const MOBILE = { width: 390, height: 844 };
+
+/**
+ * Both menus render in the DOM at every width, hidden by CSS at the wrong
+ * breakpoint, so the trigger is picked by visibility. Scoped to <nav> and
+ * matched exactly: accessible-name search is a substring match, so an
+ * unscoped "More" also catches the cookie banner's "Learn more".
+ */
+const visibleMoreTrigger = (page: import("@playwright/test").Page) =>
+  page
+    .locator("nav")
+    .getByRole("button", { name: "More", exact: true })
+    .filter({ visible: true });
+
+const openAndFollowFirstLink = async (
+  page: import("@playwright/test").Page,
+) => {
+  const trigger = visibleMoreTrigger(page);
+  await expect(trigger).toHaveCount(1);
+  await waitForHydration(trigger);
+  await trigger.click();
+
+  // Both menus are Radix dialogs under the hood — a popover on desktop, a
+  // vaul drawer on mobile — and both portal out of the nav. Locating the
+  // panel by role avoids class names and portal internals, and survives the
+  // aria-hidden that the drawer applies to everything behind it (which does
+  // remove the trigger itself from the accessibility tree once open).
+  const panel = page.getByRole("dialog").filter({ visible: true });
+  await expect(panel).toHaveCount(1);
+
+  const link = panel.getByRole("link").first();
+  await expect(link).toBeVisible();
+
+  const href = await link.getAttribute("href");
+  expect(href, "menu link should have an href").toBeTruthy();
+
+  await link.click();
+  await page.waitForURL(`**${href}`);
+  await expect(page.locator("body")).not.toBeEmpty();
+};
+
+test("the desktop More menu opens and its links work", async ({ page }) => {
+  await page.setViewportSize(DESKTOP);
+  await page.goto("/");
+  await openAndFollowFirstLink(page);
+});
+
+test("the mobile More drawer opens and its links work", async ({ page }) => {
+  await page.setViewportSize(MOBILE);
+  await page.goto("/");
+  await openAndFollowFirstLink(page);
+});

--- a/e2e/people.spec.ts
+++ b/e2e/people.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "@playwright/test";
+import { checkPages, renderProblems } from "./support/assert";
+import { fetchSitemapPaths } from "./support/sitemap";
+import { evenlySpaced, personPaths } from "./support/select";
+
+/**
+ * Content integrity for people. Person slugs are names, so there is no date
+ * to sample by; an evenly spaced sample stays deterministic while shifting as
+ * the collection grows, which keeps any one group of entries from becoming a
+ * permanent blind spot.
+ */
+
+const SAMPLE_SIZE = 5;
+
+test("a spread of person pages render", async ({ request }) => {
+  const paths = await fetchSitemapPaths(request);
+  const people = evenlySpaced(personPaths(paths), SAMPLE_SIZE);
+
+  expect(people.length, "people found in the sitemap").toBe(SAMPLE_SIZE);
+
+  const checks = await checkPages(request, people);
+  expect(renderProblems(checks), "person pages that did not render").toEqual(
+    [],
+  );
+});

--- a/e2e/redirects.spec.ts
+++ b/e2e/redirects.spec.ts
@@ -1,0 +1,83 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "@playwright/test";
+import { mapWithConcurrency } from "./support/assert";
+import { isVercelTarget } from "./support/target";
+
+/**
+ * The ~20 redirects in vercel.json, which carry every legacy /meetups/… URL
+ * still out there in links and search results.
+ *
+ * Pure configuration, never exercised by anything else, and silent when it
+ * rots — the highest value-per-line check in the suite. It is also the one
+ * thing that genuinely cannot run locally: redirects are applied by Vercel's
+ * edge, and a node-adapter preview knows nothing about them.
+ */
+
+type Redirect = {
+  source: string;
+  destination: string;
+  statusCode?: number;
+};
+
+const vercelConfig = JSON.parse(
+  readFileSync(
+    fileURLToPath(new URL("../vercel.json", import.meta.url)),
+    "utf8",
+  ),
+) as { redirects?: Redirect[] };
+
+/** A concrete segment to stand in for `:path*` on both sides of a wildcard. */
+const WILDCARD_SAMPLE = "schedule";
+
+const concrete = (pattern: string): string =>
+  pattern.replace(/\/:path\*/g, `/${WILDCARD_SAMPLE}`);
+
+test.describe("vercel.json redirects", () => {
+  test.skip(
+    ({ baseURL }) => !isVercelTarget(baseURL),
+    "Redirects are applied by Vercel; a local node-adapter preview does not serve them.",
+  );
+
+  test("every configured redirect points where it should", async ({
+    request,
+  }) => {
+    const redirects = vercelConfig.redirects ?? [];
+    expect(
+      redirects.length,
+      "redirects declared in vercel.json",
+    ).toBeGreaterThan(0);
+
+    const problems = await mapWithConcurrency(
+      redirects,
+      5,
+      async (redirect) => {
+        const source = concrete(redirect.source);
+        const destination = concrete(redirect.destination);
+        const expectedStatus = redirect.statusCode ?? 308;
+
+        const response = await request.get(source, { maxRedirects: 0 });
+        const status = response.status();
+        if (status !== expectedStatus) {
+          return `${source} → HTTP ${status}, expected ${expectedStatus}`;
+        }
+
+        // Vercel answers with an absolute Location; only the path is portable.
+        const location = response.headers()["location"] ?? "";
+        const actual = location.startsWith("http")
+          ? new URL(location).pathname
+          : location;
+        if (actual !== destination) {
+          return `${source} → ${actual || "(no Location)"}, expected ${destination}`;
+        }
+
+        return null;
+      },
+    );
+
+    expect(
+      problems.filter((problem): problem is string => problem !== null),
+      "redirects that did not behave as configured",
+    ).toEqual([]);
+  });
+});

--- a/e2e/routes.spec.ts
+++ b/e2e/routes.spec.ts
@@ -1,0 +1,115 @@
+import { expect, test } from "@playwright/test";
+import { checkPages, renderProblems, statusProblems } from "./support/assert";
+import { fetchSitemapPaths } from "./support/sitemap";
+import { newestEvents } from "./support/select";
+
+/**
+ * Route smoke: one URL per archetype, asserted structurally.
+ *
+ * Assertions never mention content. This suite runs against real content in
+ * every environment, so a spec that knows a particular event is on the
+ * homepage starts crying wolf the week that changes.
+ */
+
+const STATIC_PAGES = [
+  "/",
+  "/about",
+  "/people",
+  "/podcasts",
+  "/news",
+  "/conferences",
+  "/resources/videos",
+  "/code-of-conduct",
+  "/brand-assets",
+  "/legal-notice",
+  "/privacy-policy",
+  "/thank-you",
+  "/call-for-papers/guidelines",
+  "/fr/events/for-kids",
+];
+
+/** One representative URL per dynamic route pattern, taken from the sitemap. */
+const ARCHETYPES: Record<string, RegExp> = {
+  event: /^\/events\/\d{4}-[^/]+$/,
+  "event schedule": /^\/events\/[^/]+\/schedule$/,
+  "event sponsors": /^\/events\/[^/]+\/sponsors$/,
+  "event subpage": /^\/events\/[^/]+\/pages\/[^/]+$/,
+  talk: /^\/events\/[^/]+\/talks\/[^/]+$/,
+  person: /^\/people\/[^/]+$/,
+  "news article": /^\/news\/article\/[^/]+$/,
+  "podcast episode": /^\/podcasts\/[^/]+\/episodes\/[^/]+$/,
+  country: /^\/events\/locations\/[^/]+$/,
+  city: /^\/events\/locations\/[^/]+\/[^/]+$/,
+  organizers: /^\/events\/locations\/[^/]+\/organizers$/,
+};
+
+test("static pages render", async ({ request }) => {
+  const checks = await checkPages(request, STATIC_PAGES);
+  expect(renderProblems(checks), "static pages that did not render").toEqual(
+    [],
+  );
+});
+
+test("one page per dynamic archetype renders", async ({ request }) => {
+  const paths = await fetchSitemapPaths(request);
+
+  const sample = Object.entries(ARCHETYPES).flatMap(([name, pattern]) => {
+    const match = paths.find((path) => pattern.test(path));
+    // A missing archetype means the sitemap changed shape — worth knowing
+    // about, but it is not a rendering failure, so it is reported separately.
+    return match ? [{ name, path: match }] : [];
+  });
+
+  const missing = Object.keys(ARCHETYPES).filter(
+    (name) => !sample.some((entry) => entry.name === name),
+  );
+  expect(missing, "archetypes with no URL in the sitemap").toEqual([]);
+
+  const checks = await checkPages(
+    request,
+    sample.map((entry) => entry.path),
+  );
+  expect(renderProblems(checks), "archetype pages that did not render").toEqual(
+    [],
+  );
+});
+
+test("routes excluded from the sitemap still render", async ({ request }) => {
+  const paths = await fetchSitemapPaths(request);
+  const [event] = newestEvents(paths, 1);
+  expect(event, "no event found in the sitemap").toBeTruthy();
+
+  // The sitemap() config filters these out deliberately, so nothing else in
+  // the suite would ever touch them.
+  //
+  // /events/:id/prospectus is intentionally absent: it redirects to a href
+  // stored on the event and 404s for events without one, so there is no slug
+  // the suite can derive that is guaranteed to work.
+  const checks = await checkPages(request, [
+    `${event}/attendee`,
+    `${event}/dashboard`,
+  ]);
+  expect(renderProblems(checks), "excluded routes that did not render").toEqual(
+    [],
+  );
+});
+
+test("the legacy index routes still point at /events", async ({ request }) => {
+  // These two respond 200 with a meta-refresh stub rather than a real page,
+  // so they are checked for reachability and destination, not for content.
+  const paths = ["/events/types", "/events/locations"];
+  const checks = await checkPages(request, paths);
+  expect(statusProblems(checks), "legacy index routes").toEqual([]);
+
+  for (const path of paths) {
+    const body = await (await request.get(path)).text();
+    expect(body, `${path} should redirect to /events`).toContain("/events");
+  }
+});
+
+test("an unknown URL returns 404", async ({ request }) => {
+  const response = await request.get("/this-page-does-not-exist", {
+    maxRedirects: 0,
+  });
+  expect(response.status()).toBe(404);
+});

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -55,10 +55,23 @@ test("the search palette finds and opens a result", async ({
     timeout: 45_000,
   });
 
-  await input.fill(query);
-  await expect(results.first(), `no result for "${query}"`).toBeVisible();
+  // With an empty query the palette lists the entire index — 157 entries at
+  // the time of writing, four of which already match the term below. So
+  // neither "an option is visible" nor "an option matches the query" proves
+  // anything on its own: both hold before a single key is pressed. Waiting
+  // for the count to change is what actually proves the search ran.
+  const unfilteredCount = await results.count();
+  expect(unfilteredCount, "palette should list the index").toBeGreaterThan(1);
 
-  await results.first().click();
+  await input.fill(query);
+  await expect(results, "typing should narrow the list").not.toHaveCount(
+    unfilteredCount,
+  );
+
+  const match = results.filter({ hasText: query }).first();
+  await expect(match, `no result matching "${query}"`).toBeVisible();
+
+  await match.click();
   await page.waitForURL((url) => url.pathname !== "/");
   await expect(page.locator("body")).not.toBeEmpty();
 });

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test, waitForHydration } from "./support/browser";
+import { fetchSitemapPaths } from "./support/sitemap";
+import { newestEvents } from "./support/select";
+
+/**
+ * The search palette. A browser is unavoidable here: the results are rendered
+ * by a hydrated island backed by an Astro action, so nothing about this is
+ * reachable over plain HTTP.
+ *
+ * The query is derived from the sitemap rather than hard-coded, which keeps
+ * the suite's no-content-strings rule intact — a pinned search term would go
+ * stale the moment that event drops out of the collection.
+ *
+ * Opened by clicking the button rather than pressing the ⌘K/Ctrl+K shortcut
+ * it also supports: the modifier differs between a maintainer's macOS and
+ * CI's Linux, and a platform branch is a flake source in a merge-blocking
+ * check. If the shortcut itself ever needs cover, that is its own spec.
+ */
+
+/** `/events/2026-vietnam-hanoi` → `vietnam`, a word certain to be in its title. */
+const queryFromEvent = (eventPath: string): string => {
+  const word = eventPath
+    .split("/")
+    .at(-1)
+    ?.split("-")
+    .find((part) => part.length >= 4 && !/^\d+$/.test(part));
+  if (!word) throw new Error(`no usable search term in ${eventPath}`);
+  return word;
+};
+
+test("the search palette finds and opens a result", async ({
+  page,
+  request,
+}) => {
+  const paths = await fetchSitemapPaths(request);
+  const [event] = newestEvents(paths, 1);
+  expect(event, "no event found in the sitemap").toBeTruthy();
+  const query = queryFromEvent(event ?? "");
+
+  await page.goto("/");
+  const openSearch = page.getByRole("button", { name: "Open search modal" });
+  await waitForHydration(openSearch);
+  await openSearch.click();
+
+  const input = page.getByRole("combobox");
+  await expect(input).toBeVisible();
+
+  // The palette fetches its whole index through an Astro action, which reads
+  // every content collection and is comfortably the slowest thing in the
+  // suite when the server is busy. Wait for the default list rather than
+  // racing it, so a slow index reports as a slow index rather than as "search
+  // returned nothing".
+  const results = page.getByRole("option");
+  await expect(results.first(), "search index never loaded").toBeVisible({
+    timeout: 45_000,
+  });
+
+  await input.fill(query);
+  await expect(results.first(), `no result for "${query}"`).toBeVisible();
+
+  await results.first().click();
+  await page.waitForURL((url) => url.pathname !== "/");
+  await expect(page.locator("body")).not.toBeEmpty();
+});

--- a/e2e/sitemap.spec.ts
+++ b/e2e/sitemap.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "@playwright/test";
+import { fetchSitemapPaths } from "./support/sitemap";
+
+/**
+ * The sitemap is the URL table the rest of the suite is built on, so it gets
+ * checked in its own right: if it stops being generated, or comes back empty,
+ * every other sweep would silently pass over nothing.
+ */
+
+test("the sitemap is generated and non-trivial", async ({ request }) => {
+  const paths = await fetchSitemapPaths(request);
+
+  // Well below the real count (several hundred) — this is a floor that catches
+  // "the sitemap integration produced nothing", not a content assertion.
+  expect(paths.length).toBeGreaterThan(50);
+  expect(paths).toContain("/");
+});
+
+test("the sitemap excludes the routes it is configured to exclude", async ({
+  request,
+}) => {
+  const paths = await fetchSitemapPaths(request);
+
+  const leaked = paths.filter(
+    (path) =>
+      path.endsWith("/attendee") ||
+      path.endsWith("/prospectus") ||
+      path.endsWith("/events/locations") ||
+      path.endsWith("/events/types") ||
+      path.includes("/branding/components") ||
+      path.includes("/dashboard"),
+  );
+
+  expect(leaked, "routes that should not be in the sitemap").toEqual([]);
+});
+
+test("robots.txt is served and carries the content signal", async ({
+  request,
+}) => {
+  const response = await request.get("/robots.txt");
+  expect(response.status()).toBe(200);
+
+  const body = await response.text();
+  expect(body).toContain("User-agent: *");
+  expect(body).toContain("Content-Signal:");
+  expect(body).toContain("Sitemap:");
+});

--- a/e2e/support/assert.ts
+++ b/e2e/support/assert.ts
@@ -88,3 +88,48 @@ export const statusProblems = (checks: readonly PageCheck[]): string[] =>
   checks.flatMap((check) =>
     check.status === 200 ? [] : [`${check.path} → HTTP ${check.status}`],
   );
+
+export type BinaryCheck = {
+  path: string;
+  status: number;
+  contentType: string;
+  bytes: number;
+};
+
+export const checkBinaries = (
+  request: APIRequestContext,
+  paths: readonly string[],
+): Promise<BinaryCheck[]> =>
+  mapWithConcurrency(paths, CONCURRENCY, async (path) => {
+    const response = await request.get(path);
+    const body = await response.body();
+    return {
+      path,
+      status: response.status(),
+      contentType: response.headers()["content-type"] ?? "",
+      bytes: body.length,
+    };
+  });
+
+/**
+ * Satori's realistic failure modes are throwing outright — a bumped
+ * dependency, a font it can no longer load, CSS it no longer supports — or
+ * emitting a near-empty image. Status, content type and a size floor catch
+ * both without decoding anything, which keeps this out of visual-regression
+ * territory.
+ */
+export const binaryProblems = (
+  checks: readonly BinaryCheck[],
+  expectedType: RegExp,
+  minBytes: number,
+): string[] =>
+  checks.flatMap((check) => {
+    if (check.status !== 200) return [`${check.path} → HTTP ${check.status}`];
+    if (!expectedType.test(check.contentType)) {
+      return [`${check.path} → content-type ${check.contentType}`];
+    }
+    if (check.bytes < minBytes) {
+      return [`${check.path} → only ${check.bytes} bytes`];
+    }
+    return [];
+  });

--- a/e2e/support/assert.ts
+++ b/e2e/support/assert.ts
@@ -1,0 +1,90 @@
+import type { APIRequestContext } from "@playwright/test";
+import { pageTitle, visibleText } from "./html";
+
+/**
+ * Enough parallelism to keep a few dozen URLs quick, low enough not to look
+ * like a small denial of service to a cold preview deployment.
+ */
+const CONCURRENCY = 10;
+
+export const mapWithConcurrency = async <T, R>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> => {
+  const results: R[] = new Array<R>(items.length);
+  let cursor = 0;
+
+  const worker = async (): Promise<void> => {
+    for (;;) {
+      const index = cursor++;
+      const item = items[index];
+      if (index >= items.length || item === undefined) return;
+      results[index] = await fn(item);
+    }
+  };
+
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, worker),
+  );
+  return results;
+};
+
+export type PageCheck = {
+  path: string;
+  status: number;
+  title: string | null;
+  textLength: number;
+};
+
+/**
+ * Measured, not guessed: on this site the thinnest real page renders ~460
+ * characters of text while a meta-refresh redirect stub renders ~65. A floor
+ * of 250 separates the two with room on both sides, and catches the failure
+ * that matters — a page that responds 200 but rendered nothing.
+ *
+ * Deliberately not an <h1> check: several real pages (event sponsors, for
+ * one) have no <h1> at all, so that rule reported healthy pages as broken.
+ */
+const MIN_TEXT_LENGTH = 250;
+
+export const checkPages = (
+  request: APIRequestContext,
+  paths: readonly string[],
+): Promise<PageCheck[]> =>
+  mapWithConcurrency(paths, CONCURRENCY, async (path) => {
+    const response = await request.get(path);
+    const status = response.status();
+    if (status !== 200) return { path, status, title: null, textLength: 0 };
+
+    const html = await response.text();
+    return {
+      path,
+      status,
+      title: pageTitle(html),
+      textLength: visibleText(html).length,
+    };
+  });
+
+/**
+ * Returns a human-readable list of what went wrong, so a spec can assert
+ * `toEqual([])` once and get every broken URL in a single diff rather than
+ * failing on the first one and hiding the rest.
+ */
+export const renderProblems = (checks: readonly PageCheck[]): string[] =>
+  checks.flatMap((check) => {
+    if (check.status !== 200) return [`${check.path} → HTTP ${check.status}`];
+    if (!check.title) return [`${check.path} → no <title>`];
+    if (check.textLength < MIN_TEXT_LENGTH) {
+      return [
+        `${check.path} → rendered only ${check.textLength} characters of text`,
+      ];
+    }
+    return [];
+  });
+
+/** For endpoints where only the status matters. */
+export const statusProblems = (checks: readonly PageCheck[]): string[] =>
+  checks.flatMap((check) =>
+    check.status === 200 ? [] : [`${check.path} → HTTP ${check.status}`],
+  );

--- a/e2e/support/browser.ts
+++ b/e2e/support/browser.ts
@@ -1,0 +1,65 @@
+import { test as base, type Locator } from "@playwright/test";
+
+export { expect } from "@playwright/test";
+
+/**
+ * Consent state for the Orejime banner, pre-set so it never renders.
+ *
+ * Two reasons this is not optional. It overlays the page and intercepts
+ * clicks, and its "Learn more" button matches an accessible-name search for
+ * "More" — which is how it first showed up here, as a phantom second nav
+ * trigger. Dismissing it in each spec would be three copies of the same
+ * click and one more thing to remember when adding a fourth browser spec.
+ */
+const CONSENT_COOKIE = "forkit-consent";
+
+export const test = base.extend({
+  context: async ({ context, baseURL }, use) => {
+    if (baseURL) {
+      await context.addCookies([
+        {
+          name: CONSENT_COOKIE,
+          value: JSON.stringify({ marketing: false, analytics: false }),
+          url: baseURL,
+        },
+      ]);
+    }
+    await use(context);
+  },
+});
+
+/**
+ * Wait for the Astro island containing `target` to hydrate.
+ *
+ * Every interactive element in these specs is server-rendered first and wired
+ * up later, so Playwright happily clicks a button that has no handler yet and
+ * the click goes nowhere. It looks like a broken feature and it is really a
+ * race — one that only shows up when the machine is busy, which is to say on
+ * CI, which is to say on exactly the runs that block a merge.
+ *
+ * Astro marks a pending island with an `ssr` attribute and removes it on
+ * hydration. Waiting globally is not an option: most islands on a page are
+ * `client:visible` and stay pending forever below the fold, so this waits on
+ * the one island that matters.
+ */
+export const waitForHydration = async (target: Locator): Promise<void> => {
+  await target.evaluate(
+    (element) =>
+      new Promise<void>((resolve) => {
+        const island = element.closest("astro-island");
+        if (!island || !island.hasAttribute("ssr")) {
+          resolve();
+          return;
+        }
+        const observer = new MutationObserver(() => {
+          if (island.hasAttribute("ssr")) return;
+          observer.disconnect();
+          resolve();
+        });
+        observer.observe(island, {
+          attributes: true,
+          attributeFilter: ["ssr"],
+        });
+      }),
+  );
+};

--- a/e2e/support/html.ts
+++ b/e2e/support/html.ts
@@ -4,7 +4,8 @@
  * empty, a link points somewhere — and that does not need a parse tree.
  */
 
-const H1 = /<h1\b[^>]*>([\s\S]*?)<\/h1>/i;
+const TITLE = /<title[^>]*>([\s\S]*?)<\/title>/i;
+const SCRIPT_OR_STYLE = /<(script|style)\b[\s\S]*?<\/\1>/gi;
 const TAG = /<[^>]*>/g;
 const HREF = /<a\b[^>]*\shref=["']([^"']*)["']/gi;
 
@@ -15,11 +16,22 @@ const stripTags = (html: string): string =>
     .replace(/\s+/g, " ")
     .trim();
 
-/** Text of the first <h1>, tags stripped. `null` when there is no <h1> at all. */
-export const headingText = (html: string): string | null => {
-  const match = H1.exec(html);
+/** Contents of <title>, or `null` when the document has none. */
+export const pageTitle = (html: string): string | null => {
+  const match = TITLE.exec(html);
   return match?.[1] === undefined ? null : stripTags(match[1]);
 };
+
+/**
+ * Rendered text, with script and style contents removed.
+ *
+ * Used as a volume signal rather than for its content: an empty shell, a
+ * meta-refresh stub or a page whose data failed to load all collapse to
+ * almost nothing, while any real page on this site clears several hundred
+ * characters comfortably.
+ */
+export const visibleText = (html: string): string =>
+  stripTags(html.replace(SCRIPT_OR_STYLE, " "));
 
 const SKIPPED_PROTOCOLS = ["mailto:", "tel:", "javascript:", "data:"];
 

--- a/e2e/support/html.ts
+++ b/e2e/support/html.ts
@@ -1,0 +1,54 @@
+/**
+ * Tiny HTML helpers. Deliberately regex-based rather than pulling in a DOM
+ * parser: the suite asserts structure only — a heading exists and is not
+ * empty, a link points somewhere — and that does not need a parse tree.
+ */
+
+const H1 = /<h1\b[^>]*>([\s\S]*?)<\/h1>/i;
+const TAG = /<[^>]*>/g;
+const HREF = /<a\b[^>]*\shref=["']([^"']*)["']/gi;
+
+const stripTags = (html: string): string =>
+  html
+    .replace(TAG, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+/** Text of the first <h1>, tags stripped. `null` when there is no <h1> at all. */
+export const headingText = (html: string): string | null => {
+  const match = H1.exec(html);
+  return match?.[1] === undefined ? null : stripTags(match[1]);
+};
+
+const SKIPPED_PROTOCOLS = ["mailto:", "tel:", "javascript:", "data:"];
+
+/**
+ * Same-origin links only.
+ *
+ * Note that links rendered as absolute canonical URLs (built from Astro's
+ * `site`) resolve to the production host, so from a preview target they are
+ * *not* same-origin and get skipped. That is the behaviour we want: a CI run
+ * on a pull request must never start crawling production.
+ */
+export const internalLinks = (html: string, pageUrl: string): string[] => {
+  const origin = new URL(pageUrl).origin;
+  const found = new Set<string>();
+
+  for (const match of html.matchAll(HREF)) {
+    const href = (match[1] ?? "").trim();
+    if (!href || href.startsWith("#")) continue;
+    if (SKIPPED_PROTOCOLS.some((protocol) => href.startsWith(protocol)))
+      continue;
+
+    try {
+      const resolved = new URL(href, pageUrl);
+      if (resolved.origin !== origin) continue;
+      found.add(`${resolved.pathname}${resolved.search}`);
+    } catch {
+      // An unparseable href is not something this suite is here to police.
+    }
+  }
+
+  return [...found].sort();
+};

--- a/e2e/support/select.ts
+++ b/e2e/support/select.ts
@@ -43,7 +43,11 @@ export const personPaths = (paths: string[]): string[] =>
  * single group of people is a permanent blind spot.
  */
 export const evenlySpaced = <T>(items: T[], count: number): T[] => {
+  if (count <= 0) return [];
   if (items.length <= count) return [...items];
+  // The step below divides by count - 1, which is a division by zero for a
+  // sample of one.
+  if (count === 1) return items[0] === undefined ? [] : [items[0]];
   const step = (items.length - 1) / (count - 1);
   return Array.from({ length: count }, (_, index) => {
     const item = items[Math.round(index * step)];

--- a/e2e/support/select.ts
+++ b/e2e/support/select.ts
@@ -1,0 +1,53 @@
+/**
+ * Sampling rules for the two collections the suite sweeps.
+ *
+ * The suite is deliberately thin, so it never hits every URL. What it samples
+ * matters more than how much: the sample has to move as content is added,
+ * otherwise newly authored content — the exact thing a content-integrity
+ * check exists for — is permanently invisible to it.
+ */
+
+/** Route segments under /events that are not events. */
+const NON_EVENT_SEGMENTS = new Set(["locations", "types", "rss.xml"]);
+
+/** Event slugs are year-prefixed (`2026-france-rouen`), so they sort by date. */
+const EVENT_PATH = /^\/events\/([^/]+)$/;
+
+export const eventPaths = (paths: string[]): string[] =>
+  paths.filter((path) => {
+    const slug = EVENT_PATH.exec(path)?.[1];
+    return !!slug && !NON_EVENT_SEGMENTS.has(slug) && /^\d{4}-/.test(slug);
+  });
+
+/**
+ * Newest first. New events rotate into the sample automatically, which is
+ * where the risk of a broken page actually lives.
+ */
+export const newestEvents = (paths: string[], count: number): string[] =>
+  eventPaths(paths)
+    .sort((a, b) => b.localeCompare(a))
+    .slice(0, count);
+
+/** Every sitemap URL nested under an event: /schedule, /sponsors, /talks/…, /pages/… */
+export const descendantsOf = (paths: string[], parent: string): string[] =>
+  paths.filter((path) => path.startsWith(`${parent}/`));
+
+const PERSON_PATH = /^\/people\/[^/]+$/;
+
+export const personPaths = (paths: string[]): string[] =>
+  paths.filter((path) => PERSON_PATH.test(path));
+
+/**
+ * People have no date to sort on — slugs are names. Even spacing keeps the
+ * sample deterministic while letting it shift as the collection grows, so no
+ * single group of people is a permanent blind spot.
+ */
+export const evenlySpaced = <T>(items: T[], count: number): T[] => {
+  if (items.length <= count) return [...items];
+  const step = (items.length - 1) / (count - 1);
+  return Array.from({ length: count }, (_, index) => {
+    const item = items[Math.round(index * step)];
+    if (item === undefined) throw new Error("evenlySpaced: index out of range");
+    return item;
+  });
+};

--- a/e2e/support/sitemap.ts
+++ b/e2e/support/sitemap.ts
@@ -1,0 +1,59 @@
+import type { APIRequestContext } from "@playwright/test";
+
+/**
+ * The sitemap is the URL table for the whole suite. It is the only source
+ * that behaves identically in all three environments — locally there is a
+ * filesystem to read, against a deployed preview there is not — and it
+ * excludes draft events by construction, since they never reach it.
+ */
+const LOC = /<loc>([^<]+)<\/loc>/g;
+
+const extractLocations = (xml: string): string[] =>
+  [...xml.matchAll(LOC)]
+    .map((match) => (match[1] ?? "").trim())
+    .filter(Boolean);
+
+/**
+ * Sitemap entries are absolute URLs built from Astro's `site` option, which
+ * on a preview deployment is the branch URL and locally is localhost. Only
+ * the pathname is portable, so that is all we keep.
+ */
+export const toPathname = (url: string): string | null => {
+  try {
+    return new URL(url).pathname;
+  } catch {
+    return null;
+  }
+};
+
+const load = async (request: APIRequestContext): Promise<string[]> => {
+  const index = await request.get("/sitemap-index.xml");
+  if (!index.ok()) {
+    throw new Error(`/sitemap-index.xml returned ${index.status()}`);
+  }
+
+  const children = extractLocations(await index.text())
+    .map(toPathname)
+    .filter((path): path is string => path !== null);
+
+  const paths = new Set<string>();
+  for (const child of children) {
+    const response = await request.get(child);
+    if (!response.ok()) {
+      throw new Error(`${child} returned ${response.status()}`);
+    }
+    for (const location of extractLocations(await response.text())) {
+      const path = toPathname(location);
+      if (path) paths.add(path);
+    }
+  }
+
+  return [...paths].sort();
+};
+
+/** Memoised per worker process — several specs need the same table. */
+let cached: Promise<string[]> | null = null;
+
+export const fetchSitemapPaths = (
+  request: APIRequestContext,
+): Promise<string[]> => (cached ??= load(request));

--- a/e2e/support/target.ts
+++ b/e2e/support/target.ts
@@ -1,0 +1,17 @@
+/**
+ * Some behaviour only exists once the site is served by Vercel — the
+ * `vercel.json` redirects, ISR, the image service. A local `astro preview`
+ * run with the node adapter knows nothing about any of it, so the specs that
+ * cover it skip themselves rather than fail.
+ */
+const VERCEL_HOSTNAMES = [/\.vercel\.app$/, /(^|\.)forkit\.community$/];
+
+export const isVercelTarget = (baseURL: string | undefined): boolean => {
+  if (!baseURL) return false;
+  try {
+    const { hostname } = new URL(baseURL);
+    return VERCEL_HOSTNAMES.some((pattern) => pattern.test(hostname));
+  } catch {
+    return false;
+  }
+};

--- a/package.json
+++ b/package.json
@@ -10,10 +10,12 @@
     "lint": "astro check",
     "preview": "astro preview --node",
     "astro": "astro",
-    "prepare": "husky"
+    "prepare": "husky",
+    "test:e2e": "playwright install chromium && playwright test",
+    "test:e2e:ui": "playwright install chromium && playwright test --ui"
   },
   "lint-staged": {
-    "*.{ts,tsx,js,jsx,json,astro}": "prettier --write src/"
+    "*.{ts,tsx,js,jsx,json,astro}": "prettier --write"
   },
   "dependencies": {
     "@astrojs/check": "0.9.9",
@@ -80,6 +82,7 @@
     "vaul": "1.1.2"
   },
   "devDependencies": {
+    "@playwright/test": "1.62.1",
     "@tailwindcss/typography": "0.5.19",
     "@types/adm-zip": "0.5.8",
     "@types/qrcode": "1.5.6",

--- a/package.json
+++ b/package.json
@@ -97,5 +97,12 @@
   "engines": {
     "node": ">=22.12.0"
   },
-  "packageManager": "pnpm@11.0.4"
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": "^24.20.0",
+      "onFail": "download"
+    }
+  },
+  "packageManager": "pnpm@11.22.0"
 }

--- a/package.json
+++ b/package.json
@@ -97,12 +97,5 @@
   "engines": {
     "node": ">=22.12.0"
   },
-  "devEngines": {
-    "runtime": {
-      "name": "node",
-      "version": "^24.20.0",
-      "onFail": "download"
-    }
-  },
   "packageManager": "pnpm@11.22.0"
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,59 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * A single environment switch: `E2E_BASE_URL`.
+ *
+ * - unset  -> build the site with the node adapter and serve it locally
+ * - set    -> run against that target and start no server
+ *
+ * Vercel-only behaviour (the `vercel.json` redirects) is detected from the
+ * target hostname rather than from a second variable, so contributors only
+ * ever have one thing to know about.
+ */
+const baseURL = process.env.E2E_BASE_URL ?? "http://localhost:4321";
+
+/**
+ * Vercel preview deployments are protected by default. Without this header
+ * every single request comes back as a 401 from Vercel's auth wall.
+ */
+const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  // Retries hide nothing locally, but a merge-blocking check that fails on a
+  // single Vercel cold start is a check people learn to ignore.
+  retries: process.env.CI ? 2 : 0,
+  timeout: 60_000,
+  expect: { timeout: 15_000 },
+  reporter: process.env.CI
+    ? [["list"], ["html", { open: "never" }]]
+    : [["list"]],
+
+  use: {
+    ...devices["Desktop Chrome"],
+    baseURL,
+    trace: "on-first-retry",
+    extraHTTPHeaders: bypassSecret
+      ? {
+          "x-vercel-protection-bypass": bypassSecret,
+          "x-vercel-set-bypass-cookie": "true",
+        }
+      : {},
+  },
+
+  // Only start a server when no target was given. `exactOptionalPropertyTypes`
+  // rules out passing `undefined`, hence the spread.
+  ...(process.env.E2E_BASE_URL
+    ? {}
+    : {
+        webServer: {
+          command: "pnpm build:node && pnpm preview",
+          url: "http://localhost:4321",
+          reuseExistingServer: !process.env.CI,
+          // A cold build renders every satori asset template; not fast.
+          timeout: 300_000,
+        },
+      }),
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, devices } from "@playwright/test";
+import { isVercelTarget } from "./e2e/support/target";
 
 /**
  * A single environment switch: `E2E_BASE_URL`.
@@ -22,10 +23,17 @@ const localURL = `http://localhost:${LOCAL_PORT}`;
 const baseURL = process.env.E2E_BASE_URL ?? localURL;
 
 /**
- * Vercel preview deployments are protected by default. Without this header
- * every single request comes back as a 401 from Vercel's auth wall.
+ * Sent only when Deployment Protection is on, and only to Vercel hosts.
+ *
+ * The host check matters: `E2E_BASE_URL` is free-form, so without it a
+ * mistyped or hostile target would receive a credential that bypasses
+ * protection on every deployment of this project. Same predicate the
+ * redirect spec gates on, so the config and the suite agree on what
+ * "a Vercel target" means.
  */
-const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+const bypassSecret = isVercelTarget(baseURL)
+  ? process.env.VERCEL_AUTOMATION_BYPASS_SECRET
+  : undefined;
 
 export default defineConfig({
   testDir: "./e2e",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,7 +10,16 @@ import { defineConfig, devices } from "@playwright/test";
  * target hostname rather than from a second variable, so contributors only
  * ever have one thing to know about.
  */
-const baseURL = process.env.E2E_BASE_URL ?? "http://localhost:4321";
+/**
+ * A dedicated port, not Astro's default 4321. Sharing it means a dev server
+ * someone left running gets picked up instead — and a dev server serves pages
+ * but generates no sitemap and no robots.txt, so the suite would quietly test
+ * something other than what ships.
+ */
+const LOCAL_PORT = 4329;
+const localURL = `http://localhost:${LOCAL_PORT}`;
+
+const baseURL = process.env.E2E_BASE_URL ?? localURL;
 
 /**
  * Vercel preview deployments are protected by default. Without this header
@@ -49,10 +58,12 @@ export default defineConfig({
     ? {}
     : {
         webServer: {
-          command: "pnpm build:node && pnpm preview",
-          url: "http://localhost:4321",
-          reuseExistingServer: !process.env.CI,
-          // A cold build renders every satori asset template; not fast.
+          command: `pnpm build:node && pnpm preview --port ${LOCAL_PORT}`,
+          url: localURL,
+          // Never reuse: a server left over from an earlier run would serve a
+          // stale build. To iterate without rebuilding, start a server by hand
+          // and point E2E_BASE_URL at it.
+          reuseExistingServer: false,
           timeout: 300_000,
         },
       }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,6 +195,9 @@ importers:
         specifier: 1.1.2
         version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     devDependencies:
+      '@playwright/test':
+        specifier: 1.62.1
+        version: 1.62.1
       '@tailwindcss/typography':
         specifier: 0.5.19
         version: 0.5.19(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.9.0))
@@ -1394,6 +1397,11 @@ packages:
 
   '@oxc-project/types@0.137.0':
     resolution: {integrity: sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==}
+
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -3082,6 +3090,11 @@ packages:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3929,6 +3942,16 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   pngjs@5.0.0:
     resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
@@ -6123,6 +6146,10 @@ snapshots:
 
   '@oxc-project/types@0.137.0': {}
 
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
+
   '@radix-ui/number@1.1.1': {}
 
   '@radix-ui/primitive@1.1.3': {}
@@ -7804,6 +7831,9 @@ snapshots:
 
   fresh@2.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -8970,6 +9000,14 @@ snapshots:
   pify@2.3.0: {}
 
   pirates@4.0.7: {}
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pngjs@5.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,9 +213,6 @@ importers:
       lint-staged:
         specifier: 17.0.7
         version: 17.0.7
-      node:
-        specifier: runtime:^24.20.0
-        version: runtime:24.20.0
       prettier:
         specifier: 3.8.3
         version: 3.8.3
@@ -3797,138 +3794,6 @@ packages:
 
   node-releases@2.0.38:
     resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
-
-  node@runtime:24.20.0:
-    resolution:
-      type: variations
-      variants:
-        - resolution:
-            archive: tarball
-            bin:
-              node: bin/node
-            integrity: sha256-FLW9etQKtfRxX7Ti+WSFjYINlCX+KR09ZfmJJua4nB4=
-            type: binary
-            url: https://nodejs.org/download/release/v24.20.0/node-v24.20.0-aix-ppc64.tar.gz
-          targets:
-            - cpu: ppc64
-              os: aix
-        - resolution:
-            archive: tarball
-            bin:
-              node: bin/node
-            integrity: sha256-QOVgfl7LPbkZJyN3baLXXZZiYPx0p6nnMcG9Z92pa8g=
-            type: binary
-            url: https://nodejs.org/download/release/v24.20.0/node-v24.20.0-darwin-arm64.tar.gz
-          targets:
-            - cpu: arm64
-              os: darwin
-        - resolution:
-            archive: tarball
-            bin:
-              node: bin/node
-            integrity: sha256-nlsmRM8Qe++2rvymdrltMpa8EBOAlvAi7TeNYjPtgfQ=
-            type: binary
-            url: https://nodejs.org/download/release/v24.20.0/node-v24.20.0-darwin-x64.tar.gz
-          targets:
-            - cpu: x64
-              os: darwin
-        - resolution:
-            archive: tarball
-            bin:
-              node: bin/node
-            integrity: sha256-NRVgPiSHh5o5vHVxbxoq/9AnUAxkulDoRc9yyzMhkBM=
-            type: binary
-            url: https://nodejs.org/download/release/v24.20.0/node-v24.20.0-linux-arm64.tar.gz
-          targets:
-            - cpu: arm64
-              os: linux
-        - resolution:
-            archive: tarball
-            bin:
-              node: bin/node
-            integrity: sha256-pzSzbI0dFs5FXA65wymwfdEhwshVQ1UGSphhvJbDrcw=
-            type: binary
-            url: https://nodejs.org/download/release/v24.20.0/node-v24.20.0-linux-ppc64le.tar.gz
-          targets:
-            - cpu: ppc64le
-              os: linux
-        - resolution:
-            archive: tarball
-            bin:
-              node: bin/node
-            integrity: sha256-2MIktG7wHweKUj2bfbeSgjBvrigemGoVotv/6UfFMB4=
-            type: binary
-            url: https://nodejs.org/download/release/v24.20.0/node-v24.20.0-linux-s390x.tar.gz
-          targets:
-            - cpu: s390x
-              os: linux
-        - resolution:
-            archive: tarball
-            bin:
-              node: bin/node
-            integrity: sha256-1ubRu7mtSssW1YC4m+ipyafkkJJuk708MKINRuFSv4o=
-            type: binary
-            url: https://nodejs.org/download/release/v24.20.0/node-v24.20.0-linux-x64-musl.tar.gz
-          targets:
-            - cpu: x64
-              os: linux
-              libc: musl
-        - resolution:
-            archive: tarball
-            bin:
-              node: bin/node
-            integrity: sha256-hV1YH4pOsagRfjQm3iX+AncFkv68+zE2mu4f+/7p6Ow=
-            type: binary
-            url: https://nodejs.org/download/release/v24.20.0/node-v24.20.0-linux-x64.tar.gz
-          targets:
-            - cpu: x64
-              os: linux
-        - resolution:
-            archive: zip
-            bin:
-              node: node.exe
-            integrity: sha256-McZ5l0TeilRgFkMJgEDGjDaX5WyU5AfWHQ5fpfNBkdc=
-            prefix: node-v24.20.0-win-arm64
-            type: binary
-            url: https://nodejs.org/download/release/v24.20.0/node-v24.20.0-win-arm64.zip
-          targets:
-            - cpu: arm64
-              os: win32
-        - resolution:
-            archive: zip
-            bin:
-              node: node.exe
-            integrity: sha256-bKyf+8qPakcJHktcdy4GBgScOHHLZ9kAwM7d5jDlRbo=
-            prefix: node-v24.20.0-win-x64
-            type: binary
-            url: https://nodejs.org/download/release/v24.20.0/node-v24.20.0-win-x64.zip
-          targets:
-            - cpu: x64
-              os: win32
-        - resolution:
-            archive: tarball
-            bin:
-              node: bin/node
-            integrity: sha256-LIxQfMsPIIEtlSa6jKRUsWUqre9o/IutBvB/sRIt0e8=
-            type: binary
-            url: https://unofficial-builds.nodejs.org/download/release/v24.20.0/node-v24.20.0-linux-arm64-musl.tar.gz
-          targets:
-            - cpu: arm64
-              os: linux
-              libc: musl
-        - resolution:
-            archive: tarball
-            bin:
-              node: bin/node
-            integrity: sha256-muE5n+9L2JkOFXc84TJ7M2oguel9jHVJ9PQspzxD9WI=
-            type: binary
-            url: https://unofficial-builds.nodejs.org/download/release/v24.20.0/node-v24.20.0-linux-x64-musl.tar.gz
-          targets:
-            - cpu: x64
-              os: linux
-              libc: musl
-    version: 24.20.0
-    hasBin: true
 
   nopt@8.1.0:
     resolution: {integrity: sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==}
@@ -8999,8 +8864,6 @@ snapshots:
   node-releases@2.0.19: {}
 
   node-releases@2.0.38: {}
-
-  node@runtime:24.20.0: {}
 
   nopt@8.1.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,6 +213,9 @@ importers:
       lint-staged:
         specifier: 17.0.7
         version: 17.0.7
+      node:
+        specifier: runtime:^24.20.0
+        version: runtime:24.20.0
       prettier:
         specifier: 3.8.3
         version: 3.8.3
@@ -2407,15 +2410,30 @@ packages:
 
   '@volar/language-server@2.4.28':
     resolution: {integrity: sha512-NqcLnE5gERKuS4PUFwlhMxf6vqYo7hXtbMFbViXcbVkbZ905AIVWhnSo0ZNBC2V127H1/2zP7RvVOVnyITFfBw==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@volar/language-service@2.4.28':
     resolution: {integrity: sha512-Rh/wYCZJrI5vCwMk9xyw/Z+MsWxlJY1rmMZPsxUoJKfzIRjS/NF1NmnuEcrMbEVGja00aVpCsInJfixQTMdvLw==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@volar/source-map@2.4.28':
     resolution: {integrity: sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==}
 
   '@volar/typescript@2.4.28':
     resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@vscode/emmet-helper@2.11.0':
     resolution: {integrity: sha512-QLxjQR3imPZPQltfbWRnHU6JecWTF1QSWhx3GAKQpslx7y3Dp6sIIXhKjiUJ/BR9FX8PVthjr9PD6pNwOJfAzw==}
@@ -3780,6 +3798,138 @@ packages:
   node-releases@2.0.38:
     resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
 
+  node@runtime:24.20.0:
+    resolution:
+      type: variations
+      variants:
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-FLW9etQKtfRxX7Ti+WSFjYINlCX+KR09ZfmJJua4nB4=
+            type: binary
+            url: https://nodejs.org/download/release/v24.20.0/node-v24.20.0-aix-ppc64.tar.gz
+          targets:
+            - cpu: ppc64
+              os: aix
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-QOVgfl7LPbkZJyN3baLXXZZiYPx0p6nnMcG9Z92pa8g=
+            type: binary
+            url: https://nodejs.org/download/release/v24.20.0/node-v24.20.0-darwin-arm64.tar.gz
+          targets:
+            - cpu: arm64
+              os: darwin
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-nlsmRM8Qe++2rvymdrltMpa8EBOAlvAi7TeNYjPtgfQ=
+            type: binary
+            url: https://nodejs.org/download/release/v24.20.0/node-v24.20.0-darwin-x64.tar.gz
+          targets:
+            - cpu: x64
+              os: darwin
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-NRVgPiSHh5o5vHVxbxoq/9AnUAxkulDoRc9yyzMhkBM=
+            type: binary
+            url: https://nodejs.org/download/release/v24.20.0/node-v24.20.0-linux-arm64.tar.gz
+          targets:
+            - cpu: arm64
+              os: linux
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-pzSzbI0dFs5FXA65wymwfdEhwshVQ1UGSphhvJbDrcw=
+            type: binary
+            url: https://nodejs.org/download/release/v24.20.0/node-v24.20.0-linux-ppc64le.tar.gz
+          targets:
+            - cpu: ppc64le
+              os: linux
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-2MIktG7wHweKUj2bfbeSgjBvrigemGoVotv/6UfFMB4=
+            type: binary
+            url: https://nodejs.org/download/release/v24.20.0/node-v24.20.0-linux-s390x.tar.gz
+          targets:
+            - cpu: s390x
+              os: linux
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-1ubRu7mtSssW1YC4m+ipyafkkJJuk708MKINRuFSv4o=
+            type: binary
+            url: https://nodejs.org/download/release/v24.20.0/node-v24.20.0-linux-x64-musl.tar.gz
+          targets:
+            - cpu: x64
+              os: linux
+              libc: musl
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-hV1YH4pOsagRfjQm3iX+AncFkv68+zE2mu4f+/7p6Ow=
+            type: binary
+            url: https://nodejs.org/download/release/v24.20.0/node-v24.20.0-linux-x64.tar.gz
+          targets:
+            - cpu: x64
+              os: linux
+        - resolution:
+            archive: zip
+            bin:
+              node: node.exe
+            integrity: sha256-McZ5l0TeilRgFkMJgEDGjDaX5WyU5AfWHQ5fpfNBkdc=
+            prefix: node-v24.20.0-win-arm64
+            type: binary
+            url: https://nodejs.org/download/release/v24.20.0/node-v24.20.0-win-arm64.zip
+          targets:
+            - cpu: arm64
+              os: win32
+        - resolution:
+            archive: zip
+            bin:
+              node: node.exe
+            integrity: sha256-bKyf+8qPakcJHktcdy4GBgScOHHLZ9kAwM7d5jDlRbo=
+            prefix: node-v24.20.0-win-x64
+            type: binary
+            url: https://nodejs.org/download/release/v24.20.0/node-v24.20.0-win-x64.zip
+          targets:
+            - cpu: x64
+              os: win32
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-LIxQfMsPIIEtlSa6jKRUsWUqre9o/IutBvB/sRIt0e8=
+            type: binary
+            url: https://unofficial-builds.nodejs.org/download/release/v24.20.0/node-v24.20.0-linux-arm64-musl.tar.gz
+          targets:
+            - cpu: arm64
+              os: linux
+              libc: musl
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-muE5n+9L2JkOFXc84TJ7M2oguel9jHVJ9PQspzxD9WI=
+            type: binary
+            url: https://unofficial-builds.nodejs.org/download/release/v24.20.0/node-v24.20.0-linux-x64-musl.tar.gz
+          targets:
+            - cpu: x64
+              os: linux
+              libc: musl
+    version: 24.20.0
+    hasBin: true
+
   nopt@8.1.0:
     resolution: {integrity: sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -4873,16 +5023,22 @@ packages:
     resolution: {integrity: sha512-IdD13Z9N2Bu8EM6CM0fDV1E69olEYGHDU25X51YXmq8Y0CmJ2LNj6gOiBJgpS5JGUqFzECVhMNBW7R0sPdRTMQ==}
     peerDependencies:
       '@volar/language-service': ~2.4.0
+      typescript: '*'
     peerDependenciesMeta:
       '@volar/language-service':
+        optional: true
+      typescript:
         optional: true
 
   volar-service-typescript@0.0.70:
     resolution: {integrity: sha512-l46Bx4cokkUedTd74ojO5H/zqHZJ8SUuyZ0IB8JN4jfRqUM3bQFBHoOwlZCyZmOeO0A3RQNkMnFclxO4c++gsg==}
     peerDependencies:
       '@volar/language-service': ~2.4.0
+      typescript: '*'
     peerDependenciesMeta:
       '@volar/language-service':
+        optional: true
+      typescript:
         optional: true
 
   volar-service-yaml@0.0.70:
@@ -5154,13 +5310,13 @@ snapshots:
 
   '@astrojs/internal-helpers@0.10.0':
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
-      js-yaml: 4.2.0
-      picomatch: 4.0.4
+      js-yaml: 4.3.1
+      picomatch: 4.0.5
       retext-smartypants: 6.2.0
-      shiki: 4.2.0
-      smol-toml: 1.6.1
+      shiki: 4.4.3
+      smol-toml: 1.7.1
       unified: 11.0.5
 
   '@astrojs/internal-helpers@0.10.1':
@@ -5181,17 +5337,17 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
       '@volar/kit': 2.4.28(typescript@5.9.3)
       '@volar/language-core': 2.4.28
-      '@volar/language-server': 2.4.28
-      '@volar/language-service': 2.4.28
+      '@volar/language-server': 2.4.28(typescript@5.9.3)
+      '@volar/language-service': 2.4.28(typescript@5.9.3)
       muggle-string: 0.4.1
       tinyglobby: 0.2.17
-      volar-service-css: 0.0.70(@volar/language-service@2.4.28)
-      volar-service-emmet: 0.0.70(@volar/language-service@2.4.28)
-      volar-service-html: 0.0.70(@volar/language-service@2.4.28)
-      volar-service-prettier: 0.0.70(@volar/language-service@2.4.28)(prettier@3.8.3)
-      volar-service-typescript: 0.0.70(@volar/language-service@2.4.28)
-      volar-service-typescript-twoslash-queries: 0.0.70(@volar/language-service@2.4.28)
-      volar-service-yaml: 0.0.70(@volar/language-service@2.4.28)
+      volar-service-css: 0.0.70(@volar/language-service@2.4.28(typescript@5.9.3))
+      volar-service-emmet: 0.0.70(@volar/language-service@2.4.28(typescript@5.9.3))
+      volar-service-html: 0.0.70(@volar/language-service@2.4.28(typescript@5.9.3))
+      volar-service-prettier: 0.0.70(@volar/language-service@2.4.28(typescript@5.9.3))(prettier@3.8.3)
+      volar-service-typescript: 0.0.70(@volar/language-service@2.4.28(typescript@5.9.3))(typescript@5.9.3)
+      volar-service-typescript-twoslash-queries: 0.0.70(@volar/language-service@2.4.28(typescript@5.9.3))(typescript@5.9.3)
+      volar-service-yaml: 0.0.70(@volar/language-service@2.4.28(typescript@5.9.3))
       vscode-html-languageservice: 5.6.2
       vscode-uri: 3.1.0
     optionalDependencies:
@@ -7015,8 +7171,8 @@ snapshots:
 
   '@volar/kit@2.4.28(typescript@5.9.3)':
     dependencies:
-      '@volar/language-service': 2.4.28
-      '@volar/typescript': 2.4.28
+      '@volar/language-service': 2.4.28(typescript@5.9.3)
+      '@volar/typescript': 2.4.28(typescript@5.9.3)
       typesafe-path: 0.2.2
       typescript: 5.9.3
       vscode-languageserver-textdocument: 1.0.12
@@ -7026,32 +7182,38 @@ snapshots:
     dependencies:
       '@volar/source-map': 2.4.28
 
-  '@volar/language-server@2.4.28':
+  '@volar/language-server@2.4.28(typescript@5.9.3)':
     dependencies:
       '@volar/language-core': 2.4.28
-      '@volar/language-service': 2.4.28
-      '@volar/typescript': 2.4.28
+      '@volar/language-service': 2.4.28(typescript@5.9.3)
+      '@volar/typescript': 2.4.28(typescript@5.9.3)
       path-browserify: 1.0.1
       request-light: 0.7.0
       vscode-languageserver: 9.0.1
       vscode-languageserver-protocol: 3.17.5
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
+    optionalDependencies:
+      typescript: 5.9.3
 
-  '@volar/language-service@2.4.28':
+  '@volar/language-service@2.4.28(typescript@5.9.3)':
     dependencies:
       '@volar/language-core': 2.4.28
       vscode-languageserver-protocol: 3.17.5
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
+    optionalDependencies:
+      typescript: 5.9.3
 
   '@volar/source-map@2.4.28': {}
 
-  '@volar/typescript@2.4.28':
+  '@volar/typescript@2.4.28(typescript@5.9.3)':
     dependencies:
       '@volar/language-core': 2.4.28
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
+    optionalDependencies:
+      typescript: 5.9.3
 
   '@vscode/emmet-helper@2.11.0':
     dependencies:
@@ -7921,7 +8083,7 @@ snapshots:
 
   hast-util-raw@9.1.0:
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       '@types/unist': 3.0.3
       '@ungap/structured-clone': 1.3.1
       hast-util-from-parse5: 8.0.3
@@ -8838,6 +9000,8 @@ snapshots:
 
   node-releases@2.0.38: {}
 
+  node@runtime:24.20.0: {}
+
   nopt@8.1.0:
     dependencies:
       abbrev: 3.0.1
@@ -9208,7 +9372,7 @@ snapshots:
 
   rehype-raw@7.0.0:
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       hast-util-raw: 9.1.0
       vfile: 6.0.3
 
@@ -9881,7 +10045,7 @@ snapshots:
   vite@8.1.0(@types/node@25.5.2)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       postcss: 8.5.26
       rolldown: 1.1.3
       tinyglobby: 0.2.17
@@ -9897,45 +10061,46 @@ snapshots:
     optionalDependencies:
       vite: 8.1.0(@types/node@25.5.2)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.9.0)
 
-  volar-service-css@0.0.70(@volar/language-service@2.4.28):
+  volar-service-css@0.0.70(@volar/language-service@2.4.28(typescript@5.9.3)):
     dependencies:
       vscode-css-languageservice: 6.3.10
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
     optionalDependencies:
-      '@volar/language-service': 2.4.28
+      '@volar/language-service': 2.4.28(typescript@5.9.3)
 
-  volar-service-emmet@0.0.70(@volar/language-service@2.4.28):
+  volar-service-emmet@0.0.70(@volar/language-service@2.4.28(typescript@5.9.3)):
     dependencies:
       '@emmetio/css-parser': 0.4.1
       '@emmetio/html-matcher': 1.3.0
       '@vscode/emmet-helper': 2.11.0
       vscode-uri: 3.1.0
     optionalDependencies:
-      '@volar/language-service': 2.4.28
+      '@volar/language-service': 2.4.28(typescript@5.9.3)
 
-  volar-service-html@0.0.70(@volar/language-service@2.4.28):
+  volar-service-html@0.0.70(@volar/language-service@2.4.28(typescript@5.9.3)):
     dependencies:
       vscode-html-languageservice: 5.6.2
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
     optionalDependencies:
-      '@volar/language-service': 2.4.28
+      '@volar/language-service': 2.4.28(typescript@5.9.3)
 
-  volar-service-prettier@0.0.70(@volar/language-service@2.4.28)(prettier@3.8.3):
+  volar-service-prettier@0.0.70(@volar/language-service@2.4.28(typescript@5.9.3))(prettier@3.8.3):
     dependencies:
       vscode-uri: 3.1.0
     optionalDependencies:
-      '@volar/language-service': 2.4.28
+      '@volar/language-service': 2.4.28(typescript@5.9.3)
       prettier: 3.8.3
 
-  volar-service-typescript-twoslash-queries@0.0.70(@volar/language-service@2.4.28):
+  volar-service-typescript-twoslash-queries@0.0.70(@volar/language-service@2.4.28(typescript@5.9.3))(typescript@5.9.3):
     dependencies:
       vscode-uri: 3.1.0
     optionalDependencies:
-      '@volar/language-service': 2.4.28
+      '@volar/language-service': 2.4.28(typescript@5.9.3)
+      typescript: 5.9.3
 
-  volar-service-typescript@0.0.70(@volar/language-service@2.4.28):
+  volar-service-typescript@0.0.70(@volar/language-service@2.4.28(typescript@5.9.3))(typescript@5.9.3):
     dependencies:
       path-browserify: 1.0.1
       semver: 7.8.2
@@ -9944,14 +10109,15 @@ snapshots:
       vscode-nls: 5.2.0
       vscode-uri: 3.1.0
     optionalDependencies:
-      '@volar/language-service': 2.4.28
+      '@volar/language-service': 2.4.28(typescript@5.9.3)
+      typescript: 5.9.3
 
-  volar-service-yaml@0.0.70(@volar/language-service@2.4.28):
+  volar-service-yaml@0.0.70(@volar/language-service@2.4.28(typescript@5.9.3)):
     dependencies:
       vscode-uri: 3.1.0
       yaml-language-server: 1.20.0
     optionalDependencies:
-      '@volar/language-service': 2.4.28
+      '@volar/language-service': 2.4.28(typescript@5.9.3)
 
   vscode-css-languageservice@6.3.10:
     dependencies:


### PR DESCRIPTION
- **feat(e2e): scaffold playwright suite**
- **feat(e2e): add core route and content specs**
- **feat(e2e): add redirect and generated-asset specs**
- **feat(e2e): add internal link-graph spec**
- **feat(e2e): add browser specs for the hydrated surfaces**
- **ci(e2e): run the suite against Vercel previews, and document it**
- **fix(e2e): guard evenlySpaced against samples of one**
- **docs(e2e): the Vercel bypass secret is not needed**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive end-to-end coverage for routes, navigation, search, events, attendee tickets, downloads, assets, redirects, links, people pages, and sitemaps.
  * Added automated testing for local previews and deployed preview environments.
  * Added Playwright configuration with browser setup, retries, reporting, tracing, and authenticated preview testing.
  * Added validation for page rendering, links, redirects, generated assets, downloads, and sitemap behavior.

* **Documentation**
  * Added instructions for running, interpreting, and understanding end-to-end tests locally and in CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->